### PR TITLE
fix: preserve JSON Schema Draft 2020-12 combinators for Claude models

### DIFF
--- a/PR_DOCUMENTATION.md
+++ b/PR_DOCUMENTATION.md
@@ -1,0 +1,204 @@
+# Pull Request: Fix JSON Schema Validation for Claude Models
+
+## Overview
+
+This PR resolves Issue #16 where Claude models (e.g., `claude-opus-4-5-thinking`) were failing with JSON schema validation errors when using MCP tools that contain `anyOf`, `allOf`, or `oneOf` keywords.
+
+**Error Message:**
+```
+tools.X.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
+```
+
+## Problem
+
+The previous implementation in `src/plugin/request.ts` contained a `sanitizeSchema` function that **aggressively stripped** all `anyOf`, `allOf`, and `oneOf` keywords from tool schemas when preparing requests for Claude models. This was based on an incorrect assumption that these features were "not well supported."
+
+### Impact
+
+- **MongoDB MCP Server**: Failed completely on Claude models (worked on Gemini)
+- **Firecrawl MCP**: Failed on Claude models
+- **Any MCP tool using schema combinators**: Would fail with validation errors
+- **Tools with no parameters**: Got overly permissive `{ type: "object" }` schema instead of strict void schema
+
+### Root Cause
+
+The sanitization logic would transform valid schemas like:
+
+```json
+{
+  "type": "array",
+  "items": {
+    "anyOf": [
+      { "name": { "enum": ["aggregate"] } },
+      { "name": { "enum": ["find"] } },
+      { "name": { "enum": ["count"] } }
+    ]
+  }
+}
+```
+
+Into broken schemas:
+
+```json
+{
+  "type": "array",
+  "items": {}  // ❌ Invalid - no type constraints
+}
+```
+
+## Solution
+
+### Changes Made
+
+1. **Replaced `sanitizeSchema` with `normalizeSchemaRecursive`** (`src/plugin/request.ts:252-280`)
+   - **Preserves** `anyOf`, `allOf`, `oneOf` keywords (valid in JSON Schema Draft 2020-12)
+   - Recursively processes nested schemas while maintaining structure
+   - No longer strips valid schema features
+
+2. **Improved Void Schema Handling** (`src/plugin/request.ts:282-303`)
+   - Empty/missing schemas now normalize to: `{ type: "object", properties: {}, additionalProperties: false }`
+   - This strict format prevents tools from accepting arbitrary parameters
+   - Complies with Anthropic's API requirements
+
+3. **Safe Deep Cloning** (`src/plugin/request.ts:305`)
+   - Uses `structuredClone()` to prevent mutation of original tool definitions
+   - Ensures input schemas remain unchanged during normalization
+
+4. **Comprehensive Test Coverage** (`src/plugin/request.test.ts`)
+   - Tests Claude schema preservation with `anyOf`/`allOf`/`oneOf`
+   - Validates void schema normalization
+   - Confirms non-Claude (Gemini) path still works
+   - Verifies immutability (no mutation of input)
+
+### Technical Details
+
+**Why This Works:**
+
+- Anthropic's Claude API **fully supports** JSON Schema Draft 2020-12, including schema combinators
+- Google's Antigravity gateway proxies Claude requests and preserves these features
+- The error was caused by our overzealous sanitization, not by the API itself
+
+**Proof:**
+
+- Gemini models (using the same Antigravity backend) worked fine with `anyOf` schemas
+- Research confirmed Claude API supports JSON Schema Draft 2020-12 spec
+- Backend architect review validated this approach
+
+## Testing
+
+### Build & Test Results
+
+```bash
+npm run build  # ✅ Passes
+npm test       # ✅ All 14 tests pass (4 new)
+```
+
+### Test Coverage
+
+New tests in `src/plugin/request.test.ts`:
+
+1. **`preserves Claude tool schemas that reference anyOf/allOf/oneOf`**
+   - Verifies complex schemas with combinators are preserved
+   - Checks all three keyword types
+
+2. **`normalizes Claude tools without schemas into void schema`**
+   - Ensures parameterless tools get strict void schema
+   - Validates `additionalProperties: false` is set
+
+3. **`runs Gemini/standard normalization path for non-Claude models`**
+   - Confirms legacy behavior for Gemini still works
+   - Validates backward compatibility
+
+4. **`does not mutate supplied tool definitions during normalization`**
+   - Ensures original tool definitions remain unchanged
+   - Validates deep cloning works correctly
+
+## Verification
+
+### Before This Fix
+
+```bash
+# Using Claude with MongoDB MCP
+Error: tools.43.custom.input_schema: JSON schema is invalid. 
+It must match JSON Schema draft 2020-12
+```
+
+### After This Fix
+
+```bash
+# Using Claude with MongoDB MCP
+✅ Request succeeds
+✅ Tool schemas preserved correctly
+✅ Complex MCP tools work with Claude models
+```
+
+## Compatibility
+
+- **Claude Models**: ✅ Now fully compatible with MCP tools using schema combinators
+- **Gemini Models**: ✅ No changes to existing behavior
+- **Backward Compatibility**: ✅ All existing tests pass
+- **Node.js**: Requires Node.js 17+ for `structuredClone()` (already met by project)
+
+## Migration Notes
+
+No breaking changes. This is a pure bug fix that:
+- Makes Claude models work with more MCP tools
+- Improves schema handling for all models
+- Doesn't change the API or require configuration updates
+
+## Related Issues
+
+Closes #16
+
+## Commit
+
+```
+fix: preserve JSON Schema Draft 2020-12 combinators for Claude models
+
+Claude models via Antigravity were failing with 'JSON schema is invalid' 
+errors when MCP tools used anyOf/allOf/oneOf keywords. The previous 
+implementation aggressively stripped these valid schema features, creating 
+broken schemas (e.g., items: {}) that failed validation.
+
+Changes:
+- Replace sanitizeSchema with normalizeSchemaRecursive that preserves 
+  anyOf/allOf/oneOf combinators (supported by Anthropic API)
+- Use structuredClone for deep copying to prevent mutation of original 
+  tool definitions
+- Normalize void/empty schemas to strict format: 
+  {type: 'object', properties: {}, additionalProperties: false}
+- Add comprehensive unit tests for schema normalization logic
+
+Fixes #16
+```
+
+## Review Checklist
+
+- [x] Code builds without errors
+- [x] All tests pass
+- [x] New tests added for changed functionality
+- [x] No breaking changes
+- [x] Documentation updated (this PR doc)
+- [x] Commit message follows conventional commits
+- [x] Issue reference included
+
+## Next Steps
+
+Once merged:
+1. Version bump to 1.1.3 (patch release)
+2. Publish to npm
+3. Update README with release notes
+4. Close Issue #16
+
+---
+
+## For Reviewers
+
+**Key Files to Review:**
+1. `src/plugin/request.ts` (lines 246-310) - Core logic changes
+2. `src/plugin/request.test.ts` - New test coverage
+
+**Questions to Consider:**
+- Does the schema normalization logic correctly preserve combinators?
+- Are the test cases comprehensive enough?
+- Should we add any additional validation or error handling?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-antigravity-auth",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-antigravity-auth",
-      "version": "1.0.2",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3"
@@ -509,6 +509,7 @@
       "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
       "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/binary": "1.0.0"
       }
@@ -517,13 +518,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
       "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@oslojs/crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/asn1": "1.0.0",
         "@oslojs/binary": "1.0.0"
@@ -533,13 +536,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@oslojs/jwt": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
       "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oslojs/encoding": "0.4.1"
       }
@@ -548,7 +553,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
       "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -902,7 +908,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1013,7 +1018,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -1363,7 +1367,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1599,7 +1602,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1698,7 +1700,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",


### PR DESCRIPTION
# Pull Request: Fix JSON Schema Validation for Claude Models

## Overview

This PR resolves Issue #16 where Claude models (e.g., `claude-opus-4-5-thinking`) were failing with JSON schema validation errors when using MCP tools that contain `anyOf`, `allOf`, or `oneOf` keywords.

**Error Message:**
```
tools.X.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

## Problem

The previous implementation in `src/plugin/request.ts` contained a `sanitizeSchema` function that **aggressively stripped** all `anyOf`, `allOf`, and `oneOf` keywords from tool schemas when preparing requests for Claude models. This was based on an incorrect assumption that these features were "not well supported."

### Impact

- **MongoDB MCP Server**: Failed completely on Claude models (worked on Gemini)
- **Firecrawl MCP**: Failed on Claude models
- **Any MCP tool using schema combinators**: Would fail with validation errors
- **Tools with no parameters**: Got overly permissive `{ type: "object" }` schema instead of strict void schema

### Root Cause

The sanitization logic would transform valid schemas like:

```json
{
  "type": "array",
  "items": {
    "anyOf": [
      { "name": { "enum": ["aggregate"] } },
      { "name": { "enum": ["find"] } },
      { "name": { "enum": ["count"] } }
    ]
  }
}
```

Into broken schemas:

```json
{
  "type": "array",
  "items": {}  // ❌ Invalid - no type constraints
}
```

## Solution

### Changes Made

1. **Replaced `sanitizeSchema` with `normalizeSchemaRecursive`** (`src/plugin/request.ts:252-280`)
   - **Preserves** `anyOf`, `allOf`, `oneOf` keywords (valid in JSON Schema Draft 2020-12)
   - Recursively processes nested schemas while maintaining structure
   - No longer strips valid schema features

2. **Improved Void Schema Handling** (`src/plugin/request.ts:282-303`)
   - Empty/missing schemas now normalize to: `{ type: "object", properties: {}, additionalProperties: false }`
   - This strict format prevents tools from accepting arbitrary parameters
   - Complies with Anthropic's API requirements

3. **Safe Deep Cloning** (`src/plugin/request.ts:305`)
   - Uses `structuredClone()` to prevent mutation of original tool definitions
   - Ensures input schemas remain unchanged during normalization

4. **Comprehensive Test Coverage** (`src/plugin/request.test.ts`)
   - Tests Claude schema preservation with `anyOf`/`allOf`/`oneOf`
   - Validates void schema normalization
   - Confirms non-Claude (Gemini) path still works
   - Verifies immutability (no mutation of input)

### Technical Details

**Why This Works:**

- Anthropic's Claude API **fully supports** JSON Schema Draft 2020-12, including schema combinators
- Google's Antigravity gateway proxies Claude requests and preserves these features
- The error was caused by our overzealous sanitization, not by the API itself

**Proof:**

- Gemini models (using the same Antigravity backend) worked fine with `anyOf` schemas
- Research confirmed Claude API supports JSON Schema Draft 2020-12 spec
- Backend architect review validated this approach

## Testing

### Build & Test Results

```bash
npm run build  # ✅ Passes
npm test       # ✅ All 14 tests pass (4 new)
```

### Test Coverage

New tests in `src/plugin/request.test.ts`:

1. **`preserves Claude tool schemas that reference anyOf/allOf/oneOf`**
   - Verifies complex schemas with combinators are preserved
   - Checks all three keyword types

2. **`normalizes Claude tools without schemas into void schema`**
   - Ensures parameterless tools get strict void schema
   - Validates `additionalProperties: false` is set

3. **`runs Gemini/standard normalization path for non-Claude models`**
   - Confirms legacy behavior for Gemini still works
   - Validates backward compatibility

4. **`does not mutate supplied tool definitions during normalization`**
   - Ensures original tool definitions remain unchanged
   - Validates deep cloning works correctly

## Verification

### Before This Fix

```bash
# Using Claude with MongoDB MCP
Error: tools.43.custom.input_schema: JSON schema is invalid. 
It must match JSON Schema draft 2020-12
```

### After This Fix

```bash
# Using Claude with MongoDB MCP
✅ Request succeeds
✅ Tool schemas preserved correctly
✅ Complex MCP tools work with Claude models
```

## Compatibility

- **Claude Models**: ✅ Now fully compatible with MCP tools using schema combinators
- **Gemini Models**: ✅ No changes to existing behavior
- **Backward Compatibility**: ✅ All existing tests pass
- **Node.js**: Requires Node.js 17+ for `structuredClone()` (already met by project)

## Migration Notes

No breaking changes. This is a pure bug fix that:
- Makes Claude models work with more MCP tools
- Improves schema handling for all models
- Doesn't change the API or require configuration updates

## Related Issues

Closes #16

## Commit

```
fix: preserve JSON Schema Draft 2020-12 combinators for Claude models

Claude models via Antigravity were failing with 'JSON schema is invalid' 
errors when MCP tools used anyOf/allOf/oneOf keywords. The previous 
implementation aggressively stripped these valid schema features, creating 
broken schemas (e.g., items: {}) that failed validation.

Changes:
- Replace sanitizeSchema with normalizeSchemaRecursive that preserves 
  anyOf/allOf/oneOf combinators (supported by Anthropic API)
- Use structuredClone for deep copying to prevent mutation of original 
  tool definitions
- Normalize void/empty schemas to strict format: 
  {type: 'object', properties: {}, additionalProperties: false}
- Add comprehensive unit tests for schema normalization logic

Fixes #16
```

## Review Checklist

- [x] Code builds without errors
- [x] All tests pass
- [x] New tests added for changed functionality
- [x] No breaking changes
- [x] Documentation updated (this PR doc)
- [x] Commit message follows conventional commits
- [x] Issue reference included

## Next Steps

Once merged:
1. Version bump to 1.1.3 (patch release)
2. Publish to npm
3. Update README with release notes
4. Close Issue #16

---

## For Reviewers

**Key Files to Review:**
1. `src/plugin/request.ts` (lines 246-310) - Core logic changes
2. `src/plugin/request.test.ts` - New test coverage

**Questions to Consider:**
- Does the schema normalization logic correctly preserve combinators?
- Are the test cases comprehensive enough?
- Should we add any additional validation or error handling?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating tool schema normalization across model types, combinators, void-schema fallback, and immutability.

* **Bug Fixes**
  * Improved schema normalization to preserve complex JSON Schema constructs (anyOf/allOf/oneOf) and avoid mutating original tool definitions.
  * Ensured missing/invalid schemas normalize to a strict void-like object schema.

* **Documentation**
  * Updated docs describing the new normalization behavior and guarantees.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->