### PR TITLE
feat: add thinkingLevel support for Gemini 3 models per Google docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,71 @@ The `/connect` command in the TUI adds accounts non-destructively — it will ne
 - If Google revokes a refresh token (`invalid_grant`), that account is automatically removed from the pool
 - Rerun `opencode auth login` to re-add the account
 
+## Thinking Configuration
+
+Gemini models support "thinking" (extended reasoning). The plugin uses model-appropriate parameters per [Google's documentation](https://ai.google.dev/gemini-api/docs/thinking).
+
+### Gemini 3 Models (thinkingLevel)
+
+Gemini 3 models use `thinkingLevel` to control reasoning depth:
+
+| Model | Valid Levels | Default |
+|-------|--------------|---------|
+| gemini-3-pro | `"low"`, `"high"` | `"high"` (dynamic) |
+| gemini-3-flash | `"minimal"`, `"low"`, `"medium"`, `"high"` | `"high"` (dynamic) |
+
+**Default behavior:** If you don't specify a thinkingLevel, the API uses its default (`"high"` with dynamic reasoning).
+
+To override, configure in your model options in `opencode.json`:
+
+```json
+{
+  "provider": {
+    "google": {
+      "models": {
+        "gemini-3-pro-low": {
+          "name": "Gemini 3 Pro Low",
+          "options": {
+            "thinkingConfig": {
+              "thinkingLevel": "low"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Gemini 2.5 Models (thinkingBudget)
+
+Gemini 2.5 models use `thinkingBudget` (token count):
+
+| Setting | Behavior |
+|---------|----------|
+| Not set | Dynamic thinking (API decides) |
+| `0` | Disable thinking |
+| `-1` | Dynamic thinking |
+| `128` to `32768` | Fixed budget (varies by model) |
+
+```json
+{
+  "provider": {
+    "google": {
+      "models": {
+        "gemini-2.5-flash": {
+          "options": {
+            "thinkingConfig": {
+              "thinkingBudget": 8192
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Architecture & Flow
 
 For contributors and advanced users, see the detailed documentation:
@@ -387,5 +452,4 @@ Built with help and inspiration from:
 If this plugin helps you, consider supporting its continued maintenance:
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/S6S81QBOIR)
-
 

--- a/src/plugin/request-helpers.test.ts
+++ b/src/plugin/request-helpers.test.ts
@@ -244,7 +244,7 @@ describe("extractThinkingConfig", () => {
       { thinkingConfig: { includeThoughts: true } },
       undefined,
     );
-    expect(result).toEqual({ includeThoughts: true, thinkingBudget: DEFAULT_THINKING_BUDGET });
+    expect(result).toEqual({ includeThoughts: true });
   });
 });
 
@@ -252,7 +252,7 @@ describe("resolveThinkingConfig", () => {
   it("keeps thinking enabled for Claude models with assistant history", () => {
     const result = resolveThinkingConfig(
       { includeThoughts: true, thinkingBudget: 8000 },
-      true, // isThinkingModel
+      "claude-opus-4-5-thinking",
       true, // isClaudeModel
       true, // hasAssistantHistory
     );
@@ -262,7 +262,7 @@ describe("resolveThinkingConfig", () => {
   it("enables thinking for thinking-capable models without user config", () => {
     const result = resolveThinkingConfig(
       undefined,
-      true, // isThinkingModel
+      "claude-opus-4-5-thinking",
       false, // isClaudeModel
       false, // hasAssistantHistory
     );
@@ -273,7 +273,7 @@ describe("resolveThinkingConfig", () => {
     const userConfig = { includeThoughts: false, thinkingBudget: 5000 };
     const result = resolveThinkingConfig(
       userConfig,
-      true,
+      "gemini-2.5-flash",
       false,
       false,
     );
@@ -284,17 +284,24 @@ describe("resolveThinkingConfig", () => {
     const userConfig = { includeThoughts: true, thinkingBudget: 8000 };
     const result = resolveThinkingConfig(
       userConfig,
-      true,
+      "claude-opus-4-5-thinking",
       true, // isClaudeModel
       false, // no history
     );
     expect(result).toEqual(userConfig);
   });
 
+  it("skips defaults for Gemini 3/2.5 when no user config", () => {
+    const gemini3 = resolveThinkingConfig(undefined, "gemini-3-pro", false, false);
+    const gemini25 = resolveThinkingConfig(undefined, "gemini-2.5-flash", false, false);
+    expect(gemini3).toBeUndefined();
+    expect(gemini25).toBeUndefined();
+  });
+
   it("returns undefined for non-thinking model without user config", () => {
     const result = resolveThinkingConfig(
       undefined,
-      false, // not thinking model
+      "gpt-4o", // not thinking model
       false,
       false,
     );
@@ -627,8 +634,7 @@ describe("normalizeThinkingConfig", () => {
       thinkingBudget: Infinity,
       includeThoughts: true,
     });
-    // When budget is non-finite (undefined), includeThoughts is forced to false
-    expect(result).toEqual({ includeThoughts: false });
+    expect(result).toEqual({ includeThoughts: true });
   });
 });
 

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -17,7 +17,7 @@ import {
   extractUsageMetadata,
   filterUnsignedThinkingBlocks,
   filterMessagesThinkingBlocks,
-  isThinkingCapableModel,
+  isGemini3Model,
   normalizeThinkingConfig,
   parseAntigravityApiBody,
   resolveThinkingConfig,
@@ -719,7 +719,7 @@ export function prepareAntigravityRequest(
 
         const finalThinkingConfig = resolveThinkingConfig(
           userThinkingConfig,
-          isThinkingCapableModel(upstreamModel),
+          upstreamModel,
           isClaudeModel,
           hasAssistantHistory,
         );
@@ -727,6 +727,8 @@ export function prepareAntigravityRequest(
         const normalizedThinking = normalizeThinkingConfig(finalThinkingConfig);
         if (normalizedThinking) {
           const thinkingBudget = normalizedThinking.thinkingBudget;
+          const thinkingLevel = normalizedThinking.thinkingLevel;
+          const isGemini3 = isGemini3Model(upstreamModel);
           const thinkingConfig: Record<string, unknown> = isClaudeThinkingModel
             ? {
               include_thoughts: normalizedThinking.includeThoughts ?? true,
@@ -736,7 +738,15 @@ export function prepareAntigravityRequest(
             }
             : {
               includeThoughts: normalizedThinking.includeThoughts,
-              ...(typeof thinkingBudget === "number" && thinkingBudget > 0 ? { thinkingBudget } : {}),
+              ...(isGemini3
+                ? (thinkingLevel
+                  ? { thinkingLevel }
+                  : typeof thinkingBudget === "number" && thinkingBudget > 0
+                    ? { thinkingBudget }
+                    : {})
+                : typeof thinkingBudget === "number" && thinkingBudget > 0
+                  ? { thinkingBudget }
+                  : {}),
             };
 
           if (rawGenerationConfig) {


### PR DESCRIPTION
## Problem

The plugin currently uses `thinkingBudget` (a numeric token count) for all thinking-capable models, including Gemini 3. However, Google's official documentation recommends using `thinkingLevel` (a string parameter) for Gemini 3 models.

From [Google's Gemini Thinking documentation](https://ai.google.dev/gemini-api/docs/thinking):

> **Note:** Use the `thinkingLevel` parameter with Gemini 3 models. While `thinkingBudget` is accepted for backwards compatibility, using it with Gemini 3 Pro may result in suboptimal performance.

The documentation specifies:
- **Gemini 3 Pro** supports: `"low"`, `"high"` (default: `"high"`)
- **Gemini 3 Flash** supports: `"minimal"`, `"low"`, `"medium"`, `"high"` (default: `"high"`)
- **Gemini 2.5 models** should continue using `thinkingBudget`

## Solution

This PR updates the plugin to use model-appropriate thinking parameters:

1. **Added `ThinkingLevel` type** - `"minimal" | "low" | "medium" | "high"`
2. **Added model family detection functions** - `isGemini3Model()`, `isGemini25Model()`, `isGemini3ProModel()`, `isGemini3FlashModel()`
3. **Updated thinking config extraction** - Now extracts `thinkingLevel` from requests
4. **Changed default behavior for Gemini models** - No longer applies plugin defaults; lets the API use its dynamic default (`"high"`)
5. **Added validation** - Validates `thinkingLevel` against model-specific allowed values, warns and omits invalid values
6. **Added `buildApiThinkingConfig()`** - Builds model-appropriate config (uses `thinkingLevel` for Gemini 3, `thinkingBudget` for Gemini 2.5)
7. **Updated README** - Documents thinking configuration for both model families

## Important: Configuring Model Variants

**Model slugs like `gemini-3-pro-low` do NOT automatically use low thinking.** The slug is just a display name - you must explicitly configure `thinkingLevel` in your `opencode.jsonc`:

```jsonc
"gemini-3-pro-low": {
  "name": "Gemini 3 Pro Low (Antigravity)",
  "options": {
    "thinkingConfig": {
      "thinkingLevel": "low"
    }
  },
  "limit": { "context": 1048576, "output": 65535 }
}
```

Without this configuration, all Gemini 3 models default to `"high"` (set by OpenCode's `transform.ts`).

## Backward Compatibility

- Gemini 2.5 models continue to use `thinkingBudget` as before
- If a user explicitly sets `thinkingBudget` for Gemini 3 models, it will still be used (per Google's backward compatibility support)
- Existing configurations will continue to work

## Testing

- All existing tests pass
- TypeScript compilation passes
- Build succeeds
- Manually verified:
  - `gemini-3-flash` sends `thinkingLevel: "high"` ✅
  - `gemini-3-pro-low` (with config) sends `thinkingLevel: "low"` ✅
  - `gemini-2.5-flash-image` sends `thinkingBudget` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed "Thinking Configuration" docs covering Gemini 3 (thinkingLevel) and Gemini 2.5 (thinkingBudget) with examples.

* **New Features**
  * Support for thinkingLevel on Gemini 3 models.
  * Support for thinkingBudget on Gemini 2.5 models.
  * Improved model-aware handling and validation of thinking configuration so settings are interpreted more consistently across models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->