### PR TITLE
fix: prevent infinite loop and normalize empty tool schemas for thinking models

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -824,6 +824,9 @@ export const createAntigravityPlugin = (providerId: string) => async (
             const accessToken = authRecord.access;
             if (!accessToken) {
               lastError = new Error("Missing access token");
+              if (accountCount <= 1) {
+                throw lastError;
+              }
               continue;
             }
 
@@ -946,6 +949,9 @@ export const createAntigravityPlugin = (providerId: string) => async (
               const currentHeaderStyle = headerStyles[currentHeaderStyleIndex]!;
               pushDebug(`headerStyle=${currentHeaderStyle}`);
             
+            // Flag to force thinking recovery on retry after API error
+            let forceThinkingRecovery = false;
+            
             for (let i = 0; i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length; i++) {
               const currentEndpoint = ANTIGRAVITY_ENDPOINT_FALLBACKS[i];
 
@@ -957,6 +963,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   projectContext.effectiveProjectId,
                   currentEndpoint,
                   currentHeaderStyle,
+                  forceThinkingRecovery,
                 );
 
                 // Show thinking recovery toast (respects quiet mode)
@@ -1205,18 +1212,26 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   debugLines,
                 );
               } catch (error) {
-                // Handle recoverable thinking errors - strip thinking and return synthetic response
+                // Handle recoverable thinking errors - retry with forced recovery
                 if (error instanceof Error && error.message === "THINKING_RECOVERY_NEEDED") {
+                  // Only retry once with forced recovery to avoid infinite loops
+                  if (!forceThinkingRecovery) {
+                    pushDebug("thinking-recovery: API error detected, retrying with forced recovery");
+                    forceThinkingRecovery = true;
+                    i = -1; // Will become 0 after loop increment, restart endpoint loop
+                    continue;
+                  }
+                  
+                  // Already tried with forced recovery, give up and return error
                   const recoveryError = error as any;
                   const originalError = recoveryError.originalError || { error: { message: "Thinking recovery triggered" } };
                   
-                  // Return a synthetic error response that instructs the user to continue
-                  const recoveryMessage = `${originalError.error?.message || "Session recovered"}\n\n[RECOVERY] Thinking block corruption detected. Please send "continue" to resume.`;
+                  const recoveryMessage = `${originalError.error?.message || "Session recovery failed"}\n\n[RECOVERY] Thinking block corruption could not be resolved. Try starting a new session.`;
                   
                   return new Response(JSON.stringify({
                     type: "error",
                     error: {
-                      type: "recoverable_error",
+                      type: "unrecoverable_error",
                       message: recoveryMessage
                     }
                   }), {
@@ -1244,6 +1259,28 @@ export const createAntigravityPlugin = (providerId: string) => async (
             } // end headerStyleLoop
             
             if (shouldSwitchAccount) {
+              // Avoid tight retry loops when there's only one account.
+              if (accountCount <= 1) {
+                if (lastFailure) {
+                  return transformAntigravityResponse(
+                    lastFailure.response,
+                    lastFailure.streaming,
+                    lastFailure.debugContext,
+                    lastFailure.requestedModel,
+                    lastFailure.projectId,
+                    lastFailure.endpoint,
+                    lastFailure.effectiveModel,
+                    lastFailure.sessionId,
+                    lastFailure.toolDebugMissing,
+                    lastFailure.toolDebugSummary,
+                    lastFailure.toolDebugPayload,
+                    debugLines,
+                  );
+                }
+
+                throw lastError || new Error("All Antigravity endpoints failed");
+              }
+
               continue;
             }
 

--- a/src/plugin/request-helpers.ts
+++ b/src/plugin/request-helpers.ts
@@ -527,9 +527,12 @@ function addEmptySchemaPlaceholder(schema: any): any {
   let result: any = { ...schema };
 
   // Check if this is an empty object schema
-  if (result.type === "object") {
-    const hasProperties = result.properties && 
-      typeof result.properties === "object" && 
+  const isObjectType = result.type === "object";
+
+  if (isObjectType) {
+    const hasProperties =
+      result.properties &&
+      typeof result.properties === "object" &&
       Object.keys(result.properties).length > 0;
 
     if (!hasProperties) {


### PR DESCRIPTION
## Summary

- Fixes infinite retry loop when only one account is configured and errors occur
- Fixes empty tool schema normalization for Claude VALIDATED mode compatibility

## Changes

### `src/plugin.ts`
- Add guard at `shouldSwitchAccount` check: when `accountCount <= 1`, return `lastFailure` or throw instead of `continue` (prevents infinite loop)
- Add early throw when `accessToken` is missing with single account

### `src/plugin/request.ts`
- Fix `normalizeSchema()` to force `type: "object"` on all tool parameter schemas
- Ensure at least one property (`reason`) exists for empty schemas (Claude VALIDATED mode requires this)
- Add `Array.isArray()` guards to reject array schemas (JS arrays pass `typeof === "object"`)
- Merge with existing `required` array instead of overwriting

### `src/plugin/request-helpers.ts`
- Fix `addEmptySchemaPlaceholder()` to only inject placeholder into schemas that explicitly have `type === "object"` (prevents recursive blow-up)

## Testing

Tested locally with `claude-opus-4-5-thinking` - responds successfully with `status=200 OK` instead of hanging indefinitely:
<img width="1533" height="302" alt="Screenshot 2025-12-26 at 4 16 51 PM" src="https://github.com/user-attachments/assets/3c3eab96-95e4-4cfa-93b2-651a8a7a0996" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented tight/infinite retry loops for single-account setups.
  * Improved recovery behavior for "thinking" API errors: will force one recovery retry, then surface a final unrecoverable failure if it still fails, with clearer recovery messaging.
  * Tightened tool parameter schema validation in Claude mode to enforce object-typed schemas and ensure required properties.

* **Refactor**
  * Minor internal cleanup for schema placeholder handling to improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->