### PR TITLE
fix: fail fast when rate-limit wait exceeds configurable threshold (#59)

### DIFF
--- a/assets/antigravity.schema.json
+++ b/assets/antigravity.schema.json
@@ -48,6 +48,13 @@
       "default": true,
       "description": "Enable automatic plugin updates."
     },
+    "max_rate_limit_wait_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 3600,
+      "default": 300,
+      "description": "Maximum time in seconds to wait when all accounts are rate-limited. If the minimum wait time exceeds this, fails fast with an error. Set to 0 to disable (wait indefinitely)."
+    },
     "signature_cache": {
       "type": "object",
       "description": "Signature cache configuration for persisting thinking block signatures. Only used when keep_thinking is enabled.",

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -196,6 +196,21 @@ export const AntigravityConfigSchema = z.object({
   proactive_refresh_check_interval_seconds: z.number().min(30).max(1800).default(300),
   
   // =========================================================================
+  // Rate Limiting
+  // =========================================================================
+  
+  /**
+   * Maximum time in seconds to wait when all accounts are rate-limited.
+   * If the minimum wait time across all accounts exceeds this threshold,
+   * the plugin fails fast with an error instead of hanging.
+   * 
+   * Set to 0 to disable (wait indefinitely).
+   * 
+   * @default 300 (5 minutes)
+   */
+  max_rate_limit_wait_seconds: z.number().min(0).max(3600).default(300),
+  
+  // =========================================================================
   // Auto-Update
   // =========================================================================
   
@@ -226,6 +241,7 @@ export const DEFAULT_CONFIG: AntigravityConfig = {
   proactive_token_refresh: true,
   proactive_refresh_buffer_seconds: 1800,
   proactive_refresh_check_interval_seconds: 300,
+  max_rate_limit_wait_seconds: 300,
   auto_update: true,
   signature_cache: {
     enabled: true,


### PR DESCRIPTION
## Summary

Fixes #59 - Plugin hangs indefinitely when all accounts are rate-limited with huge `retry-after` values.

- Add `max_rate_limit_wait_seconds` config option (default: 300 seconds / 5 minutes)
- When minimum wait time across all accounts exceeds threshold, fail fast with a clear error
- Set to `0` to disable fail-fast and wait indefinitely (previous behavior)

## Configuration

```json
// ~/.config/opencode/antigravity.json
{
  "max_rate_limit_wait_seconds": 600  // 10 minutes, or 0 to disable
}
```

## Error Message

When triggered, users see:
```
All accounts rate-limited. Minimum wait: X seconds (quota resets ~HH:MM:SS).
Consider adding more accounts or waiting for quota reset.
```

## Changes

- `src/plugin/config/schema.ts` - Added Zod schema for new config option
- `assets/antigravity.schema.json` - Added JSON schema for IDE autocomplete
- `src/plugin.ts` - Updated rate-limit logic to use config value

## Testing

- All 164 existing tests pass
- Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum wait time for rate-limit scenarios (default 300s, range 0–3600). When all accounts are rate-limited, operations now either wait up to the cap or fail fast if the required wait exceeds it.
  * Improved user messaging: explicit error shown with the formatted wait time and guidance when the cap triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->