### PR TITLE
fix: strip thoughtSignature from tool metadata for Claude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.2.5-beta.5",
+    "version": "1.2.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-antigravity-auth",
-            "version": "1.2.5-beta.5",
+            "version": "1.2.6",
             "license": "MIT",
             "dependencies": {
                 "@openauthjs/openauth": "^0.4.3",


### PR DESCRIPTION
## Summary
This PR fixes the `Invalid signature in thinking block` error that occurs when switching from Gemini to Claude mid-session.

## Changes
- Implemented `stripGoogleThoughtSignature` to remove Gemini-specific `thoughtSignature` metadata from tool parts.
- Modified `stripAllThinkingBlocks` to apply this cleaning to all tool blocks in the history.
- Added regression tests in `src/plugin/request-helpers.test.ts`.

## Verification
Verified that session history containing Gemini tool calls no longer causes validation errors when processed by Claude models.