### PR TITLE
fix: extend thought signature caching to Gemini 3 models

### DIFF
--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -93,7 +93,11 @@ function buildSignatureSessionKey(
 
 
 function shouldCacheThinkingSignatures(model?: string): boolean {
-  return typeof model === "string" && model.toLowerCase().includes("claude");
+  if (typeof model !== "string") return false;
+  const lower = model.toLowerCase();
+  // Both Claude and Gemini 3 models require thought signature caching
+  // for multi-turn conversations with function calling
+  return lower.includes("claude") || lower.includes("gemini-3");
 }
 
 function hashConversationSeed(seed: string): string {


### PR DESCRIPTION
## Summary
- Extends `shouldCacheThinkingSignatures()` to include Gemini 3 models alongside Claude
- Enables proper thought signature handling for multi-turn conversations with function calling on Gemini 3

Fixes #83

## Changes
- Modified pattern matching in `src/plugin/request.ts` to check for `gemini-3` in model names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended model support to include Gemini-3 models alongside Claude for optimized conversation caching. Improved handling of multi-turn conversations with function calling across supported models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->