### PR TITLE
fix: apply cross-model signature sanitization to single requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.2.7-beta.1",
+    "version": "1.2.8-beta.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-antigravity-auth",
-            "version": "1.2.7-beta.1",
+            "version": "1.2.8-beta.0",
             "license": "MIT",
             "dependencies": {
                 "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.2.7-beta.7",
+    "version": "1.2.8-beta.0",
     "description": "Google Antigravity IDE OAuth auth plugin for Opencode - access Gemini 3 Pro and Claude 4.5 using Google credentials",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -1110,6 +1110,9 @@ export function prepareAntigravityRequest(
         // Attempts to restore signatures from cache for multi-turn conversations
         // Handle both Gemini-style contents[] and Anthropic-style messages[] payloads.
         if (isClaude) {
+          // Step 0: Sanitize cross-model metadata (strips Gemini signatures when sending to Claude)
+          sanitizeCrossModelPayloadInPlace(requestPayload, { targetModel: effectiveModel });
+
           // Step 1: Strip corrupted/unsigned thinking blocks FIRST
           deepFilterThinkingBlocks(requestPayload, signatureSessionKey, getCachedSignature, true);
 


### PR DESCRIPTION
## Summary
- Fixes #70 - Gemini thoughtSignature persisting when switching to Claude
- Adds `sanitizeCrossModelPayloadInPlace()` call to single request path (was only in batched requests)
- Bumps version to 1.2.8-beta.0

## Root Cause
`sanitizeCrossModelPayloadInPlace()` was only called for batched requests, not for single requests. Gemini's `thoughtSignature` in tool metadata persisted and caused Claude to reject with "Invalid signature in thinking block".

## Testing
- Unit tests: 494 passed
- Build: clean
- Manual E2E: Gemini → Claude cross-model with tool calls now works