### PR TITLE
Correct URL for opencode-antigravity-auth plugin LLM Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Enable Opencode to authenticate against **Antigravity** (Google's IDE) via OAuth
 Paste this into any LLM agent (Claude Code, OpenCode, Cursor, etc.):
 
 ```
-Install the opencode-antigravity-auth plugin and add the Antigravity model definitions to ~/.config/opencode/opencode.json by following: https://raw.githubusercontent.com/anthropics/opencode-antigravity-auth/dev/README.md
+Install the opencode-antigravity-auth plugin and add the Antigravity model definitions to ~/.config/opencode/opencode.json by following: https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/main/README.md
 ```
 
 **Option B: Manual setup**


### PR DESCRIPTION
This pull request updates the documentation for setting up authentication with Antigravity (Google's IDE) via OAuth. The main change is updating the plugin installation instructions to reference the correct repository.

Documentation update:

* Updated the plugin installation URL in the `README.md` to point to the `NoeFabris/opencode-antigravity-auth` repository instead of the previous `anthropics/opencode-antigravity-auth` repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation example links to reflect current repository structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->