### PR TITLE
docs: update LLM install instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ Create `~/.config/opencode/opencode.json`:
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-pro-low": {
-          "name": "Gemini 3 Pro Low (Antigravity)",
+          "name": "Gemini 3 Pro Low",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-pro-high": {
-          "name": "Gemini 3 Pro High (Antigravity)",
+          "name": "Gemini 3 Pro High",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
+          "name": "Gemini 3 Flash",
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },


### PR DESCRIPTION
The models without `antigravity` prefix in the name should not be used `(Antigravity)` in description, since it's a different quota model, and it confuses the user. This misleading is fixed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model display names in configuration examples for three Gemini models (Pro Low, Pro High, and Flash) to improve clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->