### PR TITLE
Update model names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ Create `~/.config/opencode/opencode.json`:
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-pro-low": {
-          "name": "Gemini 3 Pro Low (Antigravity)",
+          "name": "Gemini 3 Pro Low (Gemini)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-pro-high": {
-          "name": "Gemini 3 Pro High (Antigravity)",
+          "name": "Gemini 3 Pro High (Gemini)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3-flash": {
-          "name": "Gemini 3 Flash (Antigravity)",
+          "name": "Gemini 3 Flash (Gemini)",
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
@@ -128,32 +128,32 @@ Create `~/.config/opencode/opencode.json`:
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-sonnet-4-5-thinking-low": {
-          "name": "Claude Sonnet 4.5 Think Low (Antigravity)",
+          "name": "Claude Sonnet 4.5 Low (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-sonnet-4-5-thinking-medium": {
-          "name": "Claude Sonnet 4.5 Think Medium (Antigravity)",
+          "name": "Claude Sonnet 4.5 Medium (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-sonnet-4-5-thinking-high": {
-          "name": "Claude Sonnet 4.5 Think High (Antigravity)",
+          "name": "Claude Sonnet 4.5 High (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-opus-4-5-thinking-low": {
-          "name": "Claude Opus 4.5 Think Low (Antigravity)",
+          "name": "Claude Opus 4.5 Low (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-opus-4-5-thinking-medium": {
-          "name": "Claude Opus 4.5 Think Medium (Antigravity)",
+          "name": "Claude Opus 4.5 Medium (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-opus-4-5-thinking-high": {
-          "name": "Claude Opus 4.5 Think High (Antigravity)",
+          "name": "Claude Opus 4.5 High (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         }


### PR DESCRIPTION
I noticed there were two models identically named *"Gemini 3 Pro Low (Antigravity)"* - looks like the Gemini CLI ones are marked as Antigravity.

Also I removed the *"think"* keyword on the Claude models to make it consistent with the others.

Thanks for this plugin!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model display names in the README, standardizing naming conventions for Gemini variants and thinking model tiers. Changes affect displayed names only while preserving all underlying model identifiers and configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->