### PR TITLE
feat: add pid_offset_enabled config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Create `~/.config/opencode/antigravity.json` (or `.opencode/antigravity.json` in
 | Option | Default | Description |
 |--------|---------|-------------|
 | `account_selection_strategy` | `"sticky"` | Strategy for distributing requests across accounts |
+| `pid_offset_enabled` | `false` | Use PID-based offset for multi-session distribution |
 
 **Available strategies:**
 
@@ -469,6 +470,7 @@ OPENCODE_ANTIGRAVITY_DEBUG=1                              # debug
 OPENCODE_ANTIGRAVITY_LOG_DIR=/path                        # log_dir
 OPENCODE_ANTIGRAVITY_KEEP_THINKING=1                      # keep_thinking
 OPENCODE_ANTIGRAVITY_ACCOUNT_SELECTION_STRATEGY=round-robin  # account_selection_strategy
+OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED=1                 # pid_offset_enabled
 ```
 
 <details>
@@ -495,6 +497,7 @@ OPENCODE_ANTIGRAVITY_ACCOUNT_SELECTION_STRATEGY=round-robin  # account_selection
   "max_rate_limit_wait_seconds": 300,
   "quota_fallback": false,
   "account_selection_strategy": "sticky",
+  "pid_offset_enabled": false,
   "signature_cache": {
     "enabled": true,
     "memory_ttl_seconds": 3600,
@@ -523,7 +526,7 @@ DCP creates synthetic assistant messages that lack thinking blocks. **Our plugin
 
 ### oh-my-opencode
 
-When spawning parallel subagents, multiple processes may select the same account causing rate limit errors. **Workaround:** Add more accounts via `opencode auth login`.
+When spawning parallel subagents, multiple processes may select the same account causing rate limit errors. **Workaround:** Enable `pid_offset_enabled: true` to distribute sessions across accounts, or add more accounts via `opencode auth login`.
 
 ### Plugins You Don't Need
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -880,7 +880,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
               family, 
               model, 
               config.account_selection_strategy,
-              'antigravity'
+              'antigravity',
+              config.pid_offset_enabled,
             );
             
             if (!account) {

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -269,7 +269,8 @@ export class AccountManager {
     family: ModelFamily, 
     model?: string | null,
     strategy: AccountSelectionStrategy = 'sticky',
-    headerStyle: HeaderStyle = 'antigravity'
+    headerStyle: HeaderStyle = 'antigravity',
+    pidOffsetEnabled: boolean = false,
   ): ManagedAccount | null {
     const quotaKey = getQuotaKey(family, headerStyle, model);
 
@@ -295,9 +296,9 @@ export class AccountManager {
       }
     }
 
-    // PID-based offset for multi-session distribution
+    // PID-based offset for multi-session distribution (opt-in)
     // Different sessions (PIDs) will prefer different starting accounts
-    if (!this.sessionOffsetApplied[family] && this.accounts.length > 1) {
+    if (pidOffsetEnabled && !this.sessionOffsetApplied[family] && this.accounts.length > 1) {
       const pidOffset = process.pid % this.accounts.length;
       const baseIndex = this.currentAccountIndexByFamily[family] ?? 0;
       this.currentAccountIndexByFamily[family] = (baseIndex + pidOffset) % this.accounts.length;

--- a/src/plugin/config/loader.ts
+++ b/src/plugin/config/loader.ts
@@ -166,6 +166,13 @@ function applyEnvOverrides(config: AntigravityConfig): AntigravityConfig {
     account_selection_strategy: env.OPENCODE_ANTIGRAVITY_ACCOUNT_SELECTION_STRATEGY
       ? AccountSelectionStrategySchema.catch('sticky').parse(env.OPENCODE_ANTIGRAVITY_ACCOUNT_SELECTION_STRATEGY)
       : config.account_selection_strategy,
+
+    // OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED=1
+    pid_offset_enabled:
+      env.OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED === "1" ||
+      env.OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED === "true"
+        ? true
+        : config.pid_offset_enabled,
   };
 }
 

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -240,6 +240,20 @@ export const AntigravityConfigSchema = z.object({
    */
   account_selection_strategy: AccountSelectionStrategySchema.default('sticky'),
   
+  /**
+   * Enable PID-based account offset for multi-session distribution.
+   * 
+   * When enabled, different sessions (PIDs) will prefer different starting
+   * accounts, which helps distribute load when running multiple parallel agents.
+   * 
+   * When disabled (default), accounts start from the same index, which preserves
+   * Anthropic's prompt cache across restarts (recommended for single-session use).
+   * 
+   * Env override: OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED=1
+   * @default false
+   */
+  pid_offset_enabled: z.boolean().default(false),
+  
   // =========================================================================
   // Auto-Update
   // =========================================================================
@@ -274,6 +288,7 @@ export const DEFAULT_CONFIG: AntigravityConfig = {
   max_rate_limit_wait_seconds: 300,
   quota_fallback: false,
   account_selection_strategy: 'sticky',
+  pid_offset_enabled: false,
   auto_update: true,
   signature_cache: {
     enabled: true,


### PR DESCRIPTION
## Summary

- Adds `pid_offset_enabled` config option (default: `false`)
- PID-based account offset is now opt-in instead of always-on
- Preserves Anthropic prompt cache for single-session users by default

## Changes

| File | Change |
|------|--------|
| `schema.ts` | Add `pid_offset_enabled` with JSDoc |
| `loader.ts` | Add env var `OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED` |
| `accounts.ts` | Make PID offset conditional on config |
| `plugin.ts` | Pass config to account manager |
| `README.md` | Document new option |

## Configuration

```json
{
  "pid_offset_enabled": true  // opt-in for multi-session users
}
```

Or via environment:
```bash
OPENCODE_ANTIGRAVITY_PID_OFFSET_ENABLED=1
```

Fixes #122