### PR TITLE
fix: show message when accounts get permission denied

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,7 +6,7 @@ import { accessTokenExpired, isOAuthAuth, parseRefreshParts } from "./plugin/aut
 import { promptAddAnotherAccount, promptLoginMode, promptProjectId } from "./plugin/cli";
 import { ensureProjectContext } from "./plugin/project";
 import {
-  startAntigravityDebugRequest, 
+  startAntigravityDebugRequest,
   logAntigravityDebugResponse,
   logAccountContext,
   logRateLimitEvent,
@@ -27,6 +27,8 @@ import { resolveModelWithTier } from "./plugin/transform/model-resolver";
 import {
   isEmptyResponseBody,
   createSyntheticErrorResponse,
+  isCloudAICompanionPermissionDenied,
+  getProvisioningErrorMessage,
 } from "./plugin/request-helpers";
 import { EmptyResponseError } from "./plugin/errors";
 import { AntigravityTokenRefreshError, refreshAccessToken } from "./plugin/token";
@@ -144,7 +146,7 @@ async function openBrowser(url: string): Promise<boolean> {
       try {
         exec(`wslview "${url}"`);
         return true;
-      } catch {}
+      } catch { }
     }
     if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
       return false;
@@ -251,7 +253,7 @@ async function persistAccountPool(
   }
 
   const now = Date.now();
-  
+
   // If replaceAll is true (fresh login), start with empty accounts
   // Otherwise, load existing accounts and merge
   const stored = replaceAll ? null : await loadAccounts();
@@ -279,10 +281,10 @@ async function persistAccountPool(
     // Only use email-based deduplication if the new account has an email
     const existingByEmail = result.email ? indexByEmail.get(result.email) : undefined;
     const existingByToken = indexByRefreshToken.get(parts.refreshToken);
-    
+
     // Prefer email-based match to handle refresh token rotation
     const existingIndex = existingByEmail ?? existingByToken;
-    
+
     if (existingIndex === undefined) {
       // New account - add it
       const newIndex = accounts.length;
@@ -317,7 +319,7 @@ async function persistAccountPool(
       managedProjectId: parts.managedProjectId ?? existing.managedProjectId,
       lastUsed: now,
     };
-    
+
     // Update the token index if the token changed
     if (oldToken !== parts.refreshToken) {
       indexByRefreshToken.delete(oldToken);
@@ -330,8 +332,8 @@ async function persistAccountPool(
   }
 
   // For fresh logins, always start at index 0
-  const activeIndex = replaceAll 
-    ? 0 
+  const activeIndex = replaceAll
+    ? 0
     : (typeof stored?.activeIndex === "number" && Number.isFinite(stored.activeIndex) ? stored.activeIndex : 0);
 
   await saveAccounts({
@@ -391,12 +393,12 @@ function extractRateLimitBodyInfo(body: unknown): RateLimitBodyInfo {
   }
 
   const error = (body as { error?: unknown }).error;
-  const message = error && typeof error === "object" 
-    ? (error as { message?: string }).message 
+  const message = error && typeof error === "object"
+    ? (error as { message?: string }).message
     : undefined;
 
-  const details = error && typeof error === "object" 
-    ? (error as { details?: unknown[] }).details 
+  const details = error && typeof error === "object"
+    ? (error as { details?: unknown[] }).details
     : undefined;
 
   let reason: string | undefined;
@@ -521,37 +523,37 @@ const emptyResponseAttempts = new Map<string, number>();
  * @returns { attempt, delayMs, isDuplicate } - isDuplicate=true if within dedup window
  */
 function getRateLimitBackoff(
-  accountIndex: number, 
+  accountIndex: number,
   quotaKey: string,
   serverRetryAfterMs: number | null
 ): { attempt: number; delayMs: number; isDuplicate: boolean } {
   const now = Date.now();
   const stateKey = `${accountIndex}:${quotaKey}`;
   const previous = rateLimitStateByAccountQuota.get(stateKey);
-  
+
   // Check if this is a duplicate 429 within the dedup window
   if (previous && (now - previous.lastAt < RATE_LIMIT_DEDUP_WINDOW_MS)) {
     // Same rate limit event from concurrent request - don't increment
     const baseDelay = serverRetryAfterMs ?? 1000;
     const backoffDelay = Math.min(baseDelay * Math.pow(2, previous.consecutive429 - 1), 60_000);
-    return { 
-      attempt: previous.consecutive429, 
+    return {
+      attempt: previous.consecutive429,
       delayMs: Math.max(baseDelay, backoffDelay),
-      isDuplicate: true 
+      isDuplicate: true
     };
   }
-  
+
   // Check if we should reset (no 429 for 2 minutes) or increment
-  const attempt = previous && (now - previous.lastAt < RATE_LIMIT_STATE_RESET_MS) 
-    ? previous.consecutive429 + 1 
+  const attempt = previous && (now - previous.lastAt < RATE_LIMIT_STATE_RESET_MS)
+    ? previous.consecutive429 + 1
     : 1;
-  
-  rateLimitStateByAccountQuota.set(stateKey, { 
-    consecutive429: attempt, 
+
+  rateLimitStateByAccountQuota.set(stateKey, {
+    consecutive429: attempt,
     lastAt: now,
-    quotaKey 
+    quotaKey
   });
-  
+
   const baseDelay = serverRetryAfterMs ?? 1000;
   const backoffDelay = Math.min(baseDelay * Math.pow(2, attempt - 1), 60_000);
   return { attempt, delayMs: Math.max(baseDelay, backoffDelay), isDuplicate: false };
@@ -592,17 +594,17 @@ const FAILURE_STATE_RESET_MS = 120_000; // Reset failure count after 2 minutes o
 function trackAccountFailure(accountIndex: number): { failures: number; shouldCooldown: boolean; cooldownMs: number } {
   const now = Date.now();
   const previous = accountFailureState.get(accountIndex);
-  
+
   // Reset if last failure was more than 2 minutes ago
-  const failures = previous && (now - previous.lastFailureAt < FAILURE_STATE_RESET_MS) 
-    ? previous.consecutiveFailures + 1 
+  const failures = previous && (now - previous.lastFailureAt < FAILURE_STATE_RESET_MS)
+    ? previous.consecutiveFailures + 1
     : 1;
-  
+
   accountFailureState.set(accountIndex, { consecutiveFailures: failures, lastFailureAt: now });
-  
+
   const shouldCooldown = failures >= MAX_CONSECUTIVE_FAILURES;
   const cooldownMs = shouldCooldown ? FAILURE_COOLDOWN_MS : 0;
-  
+
   return { failures, shouldCooldown, cooldownMs };
 }
 
@@ -647,22 +649,22 @@ export const createAntigravityPlugin = (providerId: string) => async (
 ): Promise<PluginResult> => {
   // Load configuration from files and environment variables
   const config = loadConfig(directory);
-  
+
   // Initialize debug with config
   initializeDebug(config);
-  
+
   // Initialize structured logger for TUI integration
   initLogger(client);
-  
+
   // Initialize disk signature cache if keep_thinking is enabled
   // This integrates with the in-memory cacheSignature/getCachedSignature functions
   if (config.keep_thinking) {
     initDiskSignatureCache(config.signature_cache);
   }
-  
+
   // Initialize session recovery hook with full context
   const sessionRecovery = createSessionRecoveryHook({ client, directory }, config);
-  
+
   const updateChecker = createAutoUpdateCheckerHook(client, directory, {
     showStartupToast: true,
     autoUpdate: config.auto_update,
@@ -672,14 +674,14 @@ export const createAntigravityPlugin = (providerId: string) => async (
   const eventHandler = async (input: { event: { type: string; properties?: unknown } }) => {
     // Forward to update checker
     await updateChecker.event(input);
-    
+
     // Handle session recovery
     if (sessionRecovery && input.event.type === "session.error") {
       const props = input.event.properties as Record<string, unknown> | undefined;
       const sessionID = props?.sessionID as string | undefined;
       const messageID = props?.messageID as string | undefined;
       const error = props?.error;
-      
+
       if (sessionRecovery.isRecoverableError(error)) {
         const messageInfo = {
           id: messageID,
@@ -687,7 +689,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
           sessionID,
           error,
         };
-        
+
         // handleSessionRecovery now does the actual fix (injects tool_result, etc.)
         const recovered = await sessionRecovery.handleSessionRecovery(messageInfo);
 
@@ -699,8 +701,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
             path: { id: sessionID },
             body: { parts: [{ type: "text", text: config.resume_text }] },
             query: { directory },
-          }).catch(() => {});
-          
+          }).catch(() => { });
+
           // Show success toast
           const successToast = getRecoverySuccessToast();
           await client.tui.showToast({
@@ -709,7 +711,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
               message: successToast.message,
               variant: "success",
             },
-          }).catch(() => {});
+          }).catch(() => { });
         }
       }
     }
@@ -718,965 +720,1153 @@ export const createAntigravityPlugin = (providerId: string) => async (
   return {
     event: eventHandler,
     auth: {
-    provider: providerId,
-    loader: async (getAuth: GetAuth, provider: Provider): Promise<LoaderResult | Record<string, unknown>> => {
-      const auth = await getAuth();
-      
-      // If OpenCode has no valid OAuth auth, clear any stale account storage
-      if (!isOAuthAuth(auth)) {
-        try {
-          await clearAccounts();
-        } catch {
-          // ignore
-        }
-        return {};
-      }
+      provider: providerId,
+      loader: async (getAuth: GetAuth, provider: Provider): Promise<LoaderResult | Record<string, unknown>> => {
+        const auth = await getAuth();
 
-      // Validate that stored accounts are in sync with OpenCode's auth
-      // If OpenCode's refresh token doesn't match any stored account, clear stale storage
-      const authParts = parseRefreshParts(auth.refresh);
-      const storedAccounts = await loadAccounts();
-      
-      if (storedAccounts && storedAccounts.accounts.length > 0 && authParts.refreshToken) {
-        const hasMatchingAccount = storedAccounts.accounts.some(
-          (acc) => acc.refreshToken === authParts.refreshToken
-        );
-        
-        if (!hasMatchingAccount) {
-          // OpenCode's auth doesn't match any stored account - storage is stale
-          // Clear it and let the user re-authenticate
-          log.warn("Stored accounts don't match OpenCode's auth. Clearing stale storage.");
+        // If OpenCode has no valid OAuth auth, clear any stale account storage
+        if (!isOAuthAuth(auth)) {
           try {
             await clearAccounts();
           } catch {
             // ignore
           }
+          return {};
         }
-      }
 
-      const accountManager = await AccountManager.loadFromDisk(auth);
-      if (accountManager.getAccountCount() > 0) {
-        try {
-          await accountManager.saveToDisk();
-        } catch (error) {
-          log.error("Failed to persist initial account pool", { error: String(error) });
-        }
-      }
+        // Validate that stored accounts are in sync with OpenCode's auth
+        // If OpenCode's refresh token doesn't match any stored account, clear stale storage
+        const authParts = parseRefreshParts(auth.refresh);
+        const storedAccounts = await loadAccounts();
 
-      // Initialize proactive token refresh queue (ported from LLM-API-Key-Proxy)
-      let refreshQueue: ProactiveRefreshQueue | null = null;
-      if (config.proactive_token_refresh && accountManager.getAccountCount() > 0) {
-        refreshQueue = createProactiveRefreshQueue(client, providerId, {
-          enabled: config.proactive_token_refresh,
-          bufferSeconds: config.proactive_refresh_buffer_seconds,
-          checkIntervalSeconds: config.proactive_refresh_check_interval_seconds,
-        });
-        refreshQueue.setAccountManager(accountManager);
-        refreshQueue.start();
-      }
+        if (storedAccounts && storedAccounts.accounts.length > 0 && authParts.refreshToken) {
+          const hasMatchingAccount = storedAccounts.accounts.some(
+            (acc) => acc.refreshToken === authParts.refreshToken
+          );
 
-      if (isDebugEnabled()) {
-        const logPath = getLogFilePath();
-        if (logPath) {
-          try {
-            await client.tui.showToast({
-              body: { message: `Debug log: ${logPath}`, variant: "info" },
-            });
-          } catch {
-            // TUI may not be available
-          }
-        }
-      }
-
-      if (provider.models) {
-        for (const model of Object.values(provider.models)) {
-          if (model) {
-            model.cost = { input: 0, output: 0 };
-          }
-        }
-      }
-
-      return {
-        apiKey: "",
-        async fetch(input, init) {
-          // If the request is for the *other* provider, we might still want to intercept if URL matches
-          // But strict compliance means we only handle requests if the auth provider matches.
-          // Since loader is instantiated per provider, we are good.
-
-          if (!isGenerativeLanguageRequest(input)) {
-            return fetch(input, init);
-          }
-
-          const latestAuth = await getAuth();
-          if (!isOAuthAuth(latestAuth)) {
-            return fetch(input, init);
-          }
-
-          if (accountManager.getAccountCount() === 0) {
-            throw new Error("No Antigravity accounts configured. Run `opencode auth login`.");
-          }
-
-          const urlString = toUrlString(input);
-          const family = getModelFamilyFromUrl(urlString);
-          const model = extractModelFromUrl(urlString);
-          const debugLines: string[] = [];
-          const pushDebug = (line: string) => {
-            if (!isDebugEnabled()) return;
-            debugLines.push(line);
-          };
-          pushDebug(`request=${urlString}`);
-
-          type FailureContext = {
-            response: Response;
-            streaming: boolean;
-            debugContext: ReturnType<typeof startAntigravityDebugRequest>;
-            requestedModel?: string;
-            projectId?: string;
-            endpoint?: string;
-            effectiveModel?: string;
-            sessionId?: string;
-            toolDebugMissing?: number;
-            toolDebugSummary?: string;
-            toolDebugPayload?: string;
-          };
-
-          let lastFailure: FailureContext | null = null;
-          let lastError: Error | null = null;
-          const abortSignal = init?.signal ?? undefined;
-
-          // Helper to check if request was aborted
-          const checkAborted = () => {
-            if (abortSignal?.aborted) {
-              throw abortSignal.reason instanceof Error ? abortSignal.reason : new Error("Aborted");
+          if (!hasMatchingAccount) {
+            // OpenCode's auth doesn't match any stored account - storage is stale
+            // Clear it and let the user re-authenticate
+            log.warn("Stored accounts don't match OpenCode's auth. Clearing stale storage.");
+            try {
+              await clearAccounts();
+            } catch {
+              // ignore
             }
-          };
+          }
+        }
 
-          // Helper to show toast without blocking on abort
-          const showToast = async (message: string, variant: "info" | "warning" | "success" | "error") => {
-            if (abortSignal?.aborted) return;
+        const accountManager = await AccountManager.loadFromDisk(auth);
+        if (accountManager.getAccountCount() > 0) {
+          try {
+            await accountManager.saveToDisk();
+          } catch (error) {
+            log.error("Failed to persist initial account pool", { error: String(error) });
+          }
+        }
+
+        // Initialize proactive token refresh queue (ported from LLM-API-Key-Proxy)
+        let refreshQueue: ProactiveRefreshQueue | null = null;
+        if (config.proactive_token_refresh && accountManager.getAccountCount() > 0) {
+          refreshQueue = createProactiveRefreshQueue(client, providerId, {
+            enabled: config.proactive_token_refresh,
+            bufferSeconds: config.proactive_refresh_buffer_seconds,
+            checkIntervalSeconds: config.proactive_refresh_check_interval_seconds,
+          });
+          refreshQueue.setAccountManager(accountManager);
+          refreshQueue.start();
+        }
+
+        if (isDebugEnabled()) {
+          const logPath = getLogFilePath();
+          if (logPath) {
             try {
               await client.tui.showToast({
-                body: { message, variant },
+                body: { message: `Debug log: ${logPath}`, variant: "info" },
               });
             } catch {
               // TUI may not be available
             }
-          };
+          }
+        }
 
-          // Use while(true) loop to handle rate limits with backoff
-          // This ensures we wait and retry when all accounts are rate-limited
-          const quietMode = config.quiet_mode;
-          
-          const hasOtherAccountWithAntigravity = (currentAccount: any): boolean => {
-            if (family !== "gemini") return false;
-            const otherAccounts = accountManager.getAccounts().filter(acc => acc.index !== currentAccount.index);
-            return otherAccounts.some(acc => 
-              !accountManager.isRateLimitedForHeaderStyle(acc, family, "antigravity", model)
-            );
-          };
+        if (provider.models) {
+          for (const model of Object.values(provider.models)) {
+            if (model) {
+              model.cost = { input: 0, output: 0 };
+            }
+          }
+        }
 
-          while (true) {
-            // Check for abort at the start of each iteration
-            checkAborted();
-            
-            const accountCount = accountManager.getAccountCount();
-            
-            if (accountCount === 0) {
-              throw new Error("No Antigravity accounts available. Run `opencode auth login`.");
+        return {
+          apiKey: "",
+          async fetch(input, init) {
+            // If the request is for the *other* provider, we might still want to intercept if URL matches
+            // But strict compliance means we only handle requests if the auth provider matches.
+            // Since loader is instantiated per provider, we are good.
+
+            if (!isGenerativeLanguageRequest(input)) {
+              return fetch(input, init);
             }
 
-            const account = accountManager.getCurrentOrNextForFamily(family, model);
-            
-            if (!account) {
-              // All accounts are rate-limited - wait and retry
-              const waitMs = accountManager.getMinWaitTimeForFamily(family, model) || 60_000;
-              const waitSecValue = Math.max(1, Math.ceil(waitMs / 1000));
-
-              pushDebug(`all-rate-limited family=${family} accounts=${accountCount} waitMs=${waitMs}`);
-              if (isDebugEnabled()) {
-                logAccountContext("All accounts rate-limited", {
-                  index: -1,
-                  family,
-                  totalAccounts: accountCount,
-                });
-                logRateLimitSnapshot(family, accountManager.getAccountsSnapshot());
-              }
-
-              // If wait time exceeds max threshold, return error immediately instead of hanging
-              // 0 means disabled (wait indefinitely)
-              const maxWaitMs = (config.max_rate_limit_wait_seconds ?? 300) * 1000;
-              if (maxWaitMs > 0 && waitMs > maxWaitMs) {
-                const waitTimeFormatted = formatWaitTime(waitMs);
-                await showToast(
-                  `Rate limited for ${waitTimeFormatted}. Try again later or add another account.`,
-                  "error"
-                );
-                
-                // Return a proper rate limit error response
-                throw new Error(
-                  `All ${accountCount} account(s) rate-limited for ${family}. ` +
-                  `Quota resets in ${waitTimeFormatted}. ` +
-                  `Add more accounts with \`opencode auth login\` or wait and retry.`
-                );
-              }
-
-              await showToast(`All ${accountCount} account(s) rate-limited for ${family}. Waiting ${waitSecValue}s...`, "warning");
-
-              // Wait for the rate-limit cooldown to expire, then retry
-              await sleep(waitMs, abortSignal);
-              continue;
+            const latestAuth = await getAuth();
+            if (!isOAuthAuth(latestAuth)) {
+              return fetch(input, init);
             }
 
-            pushDebug(
-              `selected idx=${account.index} email=${account.email ?? ""} family=${family} accounts=${accountCount}`,
-            );
-            if (isDebugEnabled()) {
-              logAccountContext("Selected", {
-                index: account.index,
-                email: account.email,
-                family,
-                totalAccounts: accountCount,
-                rateLimitState: account.rateLimitResetTimes,
-              });
+            if (accountManager.getAccountCount() === 0) {
+              throw new Error("No Antigravity accounts configured. Run `opencode auth login`.");
             }
 
-            // Show toast when switching to a different account (debounced, respects quiet mode)
-            if (!quietMode && accountCount > 1 && accountManager.shouldShowAccountToast(account.index)) {
-              const accountLabel = account.email || `Account ${account.index + 1}`;
-              await showToast(
-                `Using ${accountLabel} (${account.index + 1}/${accountCount})`,
-                "info"
-              );
-              accountManager.markToastShown(account.index);
-            }
+            const urlString = toUrlString(input);
+            const family = getModelFamilyFromUrl(urlString);
+            const model = extractModelFromUrl(urlString);
+            const debugLines: string[] = [];
+            const pushDebug = (line: string) => {
+              if (!isDebugEnabled()) return;
+              debugLines.push(line);
+            };
+            pushDebug(`request=${urlString}`);
 
-            try {
-              await accountManager.saveToDisk();
-            } catch (error) {
-              log.error("Failed to persist rotation state", { error: String(error) });
-            }
+            type FailureContext = {
+              response: Response;
+              streaming: boolean;
+              debugContext: ReturnType<typeof startAntigravityDebugRequest>;
+              requestedModel?: string;
+              projectId?: string;
+              endpoint?: string;
+              effectiveModel?: string;
+              sessionId?: string;
+              toolDebugMissing?: number;
+              toolDebugSummary?: string;
+              toolDebugPayload?: string;
+            };
 
-            let authRecord = accountManager.toAuthDetails(account);
+            let lastFailure: FailureContext | null = null;
+            let lastError: Error | null = null;
+            const abortSignal = init?.signal ?? undefined;
 
-            if (accessTokenExpired(authRecord)) {
-              try {
-                const refreshed = await refreshAccessToken(authRecord, client, providerId);
-                if (!refreshed) {
-                  const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
-                  lastError = new Error("Antigravity token refresh failed");
-                  if (shouldCooldown) {
-                    accountManager.markAccountCoolingDown(account, cooldownMs, "auth-failure");
-                    accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
-                    pushDebug(`token-refresh-failed: cooldown ${cooldownMs}ms after ${failures} failures`);
-                  }
-                  continue;
-                }
-                resetAccountFailureState(account.index);
-                accountManager.updateFromAuth(account, refreshed);
-                authRecord = refreshed;
-                try {
-                  await accountManager.saveToDisk();
-                } catch (error) {
-                  log.error("Failed to persist refreshed auth", { error: String(error) });
-                }
-              } catch (error) {
-                if (error instanceof AntigravityTokenRefreshError && error.code === "invalid_grant") {
-                  const removed = accountManager.removeAccount(account);
-                  if (removed) {
-                    log.warn("Removed revoked account from pool - reauthenticate via `opencode auth login`");
-                    try {
-                      await accountManager.saveToDisk();
-                    } catch (persistError) {
-                      log.error("Failed to persist revoked account removal", { error: String(persistError) });
-                    }
-                  }
-
-                  if (accountManager.getAccountCount() === 0) {
-                    try {
-                      await client.auth.set({
-                        path: { id: providerId },
-                        body: { type: "oauth", refresh: "", access: "", expires: 0 },
-                      });
-                    } catch (storeError) {
-                      log.error("Failed to clear stored Antigravity OAuth credentials", { error: String(storeError) });
-                    }
-
-                    throw new Error(
-                      "All Antigravity accounts have invalid refresh tokens. Run `opencode auth login` and reauthenticate.",
-                    );
-                  }
-
-                  lastError = error;
-                  continue;
-                }
-
-                const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
-                lastError = error instanceof Error ? error : new Error(String(error));
-                if (shouldCooldown) {
-                  accountManager.markAccountCoolingDown(account, cooldownMs, "auth-failure");
-                  accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
-                  pushDebug(`token-refresh-error: cooldown ${cooldownMs}ms after ${failures} failures`);
-                }
-                continue;
-              }
-            }
-
-            const accessToken = authRecord.access;
-            if (!accessToken) {
-              lastError = new Error("Missing access token");
-              if (accountCount <= 1) {
-                throw lastError;
-              }
-              continue;
-            }
-
-            let projectContext: ProjectContextResult;
-            try {
-              projectContext = await ensureProjectContext(authRecord);
-              resetAccountFailureState(account.index);
-            } catch (error) {
-              const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
-              lastError = error instanceof Error ? error : new Error(String(error));
-              if (shouldCooldown) {
-                accountManager.markAccountCoolingDown(account, cooldownMs, "project-error");
-                accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
-                pushDebug(`project-context-error: cooldown ${cooldownMs}ms after ${failures} failures`);
-              }
-              continue;
-            }
-
-            if (projectContext.auth !== authRecord) {
-              accountManager.updateFromAuth(account, projectContext.auth);
-              authRecord = projectContext.auth;
-              try {
-                await accountManager.saveToDisk();
-              } catch (error) {
-                log.error("Failed to persist project context", { error: String(error) });
-              }
-            }
-
-            const runThinkingWarmup = async (
-              prepared: ReturnType<typeof prepareAntigravityRequest>,
-              projectId: string,
-            ): Promise<void> => {
-              if (!prepared.needsSignedThinkingWarmup || !prepared.sessionId) {
-                return;
-              }
-
-              if (!trackWarmupAttempt(prepared.sessionId)) {
-                return;
-              }
-
-              const warmupBody = buildThinkingWarmupBody(
-                typeof prepared.init.body === "string" ? prepared.init.body : undefined,
-                Boolean(prepared.effectiveModel?.toLowerCase().includes("claude") && prepared.effectiveModel?.toLowerCase().includes("thinking")),
-              );
-              if (!warmupBody) {
-                return;
-              }
-
-              const warmupUrl = toWarmupStreamUrl(prepared.request);
-              const warmupHeaders = new Headers(prepared.init.headers ?? {});
-              warmupHeaders.set("accept", "text/event-stream");
-
-              const warmupInit: RequestInit = {
-                ...prepared.init,
-                method: prepared.init.method ?? "POST",
-                headers: warmupHeaders,
-                body: warmupBody,
-              };
-
-              const warmupDebugContext = startAntigravityDebugRequest({
-                originalUrl: warmupUrl,
-                resolvedUrl: warmupUrl,
-                method: warmupInit.method,
-                headers: warmupHeaders,
-                body: warmupBody,
-                streaming: true,
-                projectId,
-              });
-
-              try {
-                pushDebug("thinking-warmup: start");
-                const warmupResponse = await fetch(warmupUrl, warmupInit);
-                const transformed = await transformAntigravityResponse(
-                  warmupResponse,
-                  true,
-                  warmupDebugContext,
-                  prepared.requestedModel,
-                  projectId,
-                  warmupUrl,
-                  prepared.effectiveModel,
-                  prepared.sessionId,
-                );
-                await transformed.text();
-                markWarmupSuccess(prepared.sessionId);
-                pushDebug("thinking-warmup: done");
-              } catch (error) {
-                clearWarmupAttempt(prepared.sessionId);
-                pushDebug(
-                  `thinking-warmup: failed ${error instanceof Error ? error.message : String(error)}`,
-                );
+            // Helper to check if request was aborted
+            const checkAborted = () => {
+              if (abortSignal?.aborted) {
+                throw abortSignal.reason instanceof Error ? abortSignal.reason : new Error("Aborted");
               }
             };
 
-            // Try endpoint fallbacks with single header style based on model suffix
-            let shouldSwitchAccount = false;
-            
-            // Determine header style from model suffix:
-            // - Models with :antigravity suffix -> use Antigravity quota
-            // - Models without suffix (default) -> use Gemini CLI quota
-            // - Claude models -> always use Antigravity
-            let headerStyle = getHeaderStyleFromUrl(urlString, family);
-            const explicitQuota = isExplicitQuotaFromUrl(urlString);
-            pushDebug(`headerStyle=${headerStyle} explicit=${explicitQuota}`);
-            
-            // Check if this header style is rate-limited for this account
-            if (accountManager.isRateLimitedForHeaderStyle(account, family, headerStyle, model)) {
-              // Quota fallback: try alternate quota on same account (if enabled and not explicit)
-              if (config.quota_fallback && !explicitQuota && family === "gemini") {
-                const alternateStyle = accountManager.getAvailableHeaderStyle(account, family, model);
-                if (alternateStyle && alternateStyle !== headerStyle) {
-                  const quotaName = headerStyle === "gemini-cli" ? "Gemini CLI" : "Antigravity";
-                  const altQuotaName = alternateStyle === "gemini-cli" ? "Gemini CLI" : "Antigravity";
-                  if (!quietMode) {
-                    await showToast(
-                      `${quotaName} quota exhausted, using ${altQuotaName} quota`,
-                      "warning"
-                    );
-                  }
-                  headerStyle = alternateStyle;
-                  pushDebug(`quota fallback: ${headerStyle}`);
-                } else {
-                  shouldSwitchAccount = true;
-                }
-              } else {
-                shouldSwitchAccount = true;
+            // Helper to show toast without blocking on abort
+            const showToast = async (message: string, variant: "info" | "warning" | "success" | "error") => {
+              if (abortSignal?.aborted) return;
+              try {
+                await client.tui.showToast({
+                  body: { message, variant },
+                });
+              } catch {
+                // TUI may not be available
               }
-            }
-            
-            while (!shouldSwitchAccount) {
-            
-            // Flag to force thinking recovery on retry after API error
-            let forceThinkingRecovery = false;
-            
-            for (let i = 0; i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length; i++) {
-              const currentEndpoint = ANTIGRAVITY_ENDPOINT_FALLBACKS[i];
+            };
+
+            // Use while(true) loop to handle rate limits with backoff
+            // This ensures we wait and retry when all accounts are rate-limited
+            const quietMode = config.quiet_mode;
+
+            const hasOtherAccountWithAntigravity = (currentAccount: any): boolean => {
+              if (family !== "gemini") return false;
+              const otherAccounts = accountManager.getAccounts().filter(acc => acc.index !== currentAccount.index);
+              return otherAccounts.some(acc =>
+                !accountManager.isRateLimitedForHeaderStyle(acc, family, "antigravity", model)
+              );
+            };
+
+            while (true) {
+              // Check for abort at the start of each iteration
+              checkAborted();
+
+              const accountCount = accountManager.getAccountCount();
+
+              if (accountCount === 0) {
+                throw new Error("No Antigravity accounts available. Run `opencode auth login`.");
+              }
+
+              const account = accountManager.getCurrentOrNextForFamily(family, model);
+
+              if (!account) {
+                // All accounts are rate-limited - wait and retry
+                const waitMs = accountManager.getMinWaitTimeForFamily(family, model) || 60_000;
+                const waitSecValue = Math.max(1, Math.ceil(waitMs / 1000));
+
+                pushDebug(`all-rate-limited family=${family} accounts=${accountCount} waitMs=${waitMs}`);
+                if (isDebugEnabled()) {
+                  logAccountContext("All accounts rate-limited", {
+                    index: -1,
+                    family,
+                    totalAccounts: accountCount,
+                  });
+                  logRateLimitSnapshot(family, accountManager.getAccountsSnapshot());
+                }
+
+                // If wait time exceeds max threshold, return error immediately instead of hanging
+                // 0 means disabled (wait indefinitely)
+                const maxWaitMs = (config.max_rate_limit_wait_seconds ?? 300) * 1000;
+                if (maxWaitMs > 0 && waitMs > maxWaitMs) {
+                  const waitTimeFormatted = formatWaitTime(waitMs);
+                  await showToast(
+                    `Rate limited for ${waitTimeFormatted}. Try again later or add another account.`,
+                    "error"
+                  );
+
+                  // Return a proper rate limit error response
+                  throw new Error(
+                    `All ${accountCount} account(s) rate-limited for ${family}. ` +
+                    `Quota resets in ${waitTimeFormatted}. ` +
+                    `Add more accounts with \`opencode auth login\` or wait and retry.`
+                  );
+                }
+
+                await showToast(`All ${accountCount} account(s) rate-limited for ${family}. Waiting ${waitSecValue}s...`, "warning");
+
+                // Wait for the rate-limit cooldown to expire, then retry
+                await sleep(waitMs, abortSignal);
+                continue;
+              }
+
+              pushDebug(
+                `selected idx=${account.index} email=${account.email ?? ""} family=${family} accounts=${accountCount}`,
+              );
+              if (isDebugEnabled()) {
+                logAccountContext("Selected", {
+                  index: account.index,
+                  email: account.email,
+                  family,
+                  totalAccounts: accountCount,
+                  rateLimitState: account.rateLimitResetTimes,
+                });
+              }
+
+              // Show toast when switching to a different account (debounced, respects quiet mode)
+              if (!quietMode && accountCount > 1 && accountManager.shouldShowAccountToast(account.index)) {
+                const accountLabel = account.email || `Account ${account.index + 1}`;
+                await showToast(
+                  `Using ${accountLabel} (${account.index + 1}/${accountCount})`,
+                  "info"
+                );
+                accountManager.markToastShown(account.index);
+              }
 
               try {
-                const prepared = prepareAntigravityRequest(
-                  input,
-                  init,
-                  accessToken,
-                  projectContext.effectiveProjectId,
-                  currentEndpoint,
-                  headerStyle,
-                  forceThinkingRecovery,
-                  {
-                    claudeToolHardening: config.claude_tool_hardening,
-                  },
-                );
+                await accountManager.saveToDisk();
+              } catch (error) {
+                log.error("Failed to persist rotation state", { error: String(error) });
+              }
 
-                // Show thinking recovery toast (respects quiet mode)
-                if (!quietMode && prepared.thinkingRecoveryMessage) {
-                  await showToast(prepared.thinkingRecoveryMessage, "warning");
-                }
+              let authRecord = accountManager.toAuthDetails(account);
 
-                const originalUrl = toUrlString(input);
-                const resolvedUrl = toUrlString(prepared.request);
-                pushDebug(`endpoint=${currentEndpoint}`);
-                pushDebug(`resolved=${resolvedUrl}`);
-                const debugContext = startAntigravityDebugRequest({
-                  originalUrl,
-                  resolvedUrl,
-                  method: prepared.init.method,
-                  headers: prepared.init.headers,
-                  body: prepared.init.body,
-                  streaming: prepared.streaming,
-                  projectId: projectContext.effectiveProjectId,
-                });
-
-                await runThinkingWarmup(prepared, projectContext.effectiveProjectId);
-
-                const response = await fetch(prepared.request, prepared.init);
-                pushDebug(`status=${response.status} ${response.statusText}`);
-
-
-
-
-                // Handle 429 rate limit with improved logic
-                if (response.status === 429) {
-                  const headerRetryMs = retryAfterMsFromResponse(response);
-                  const bodyInfo = await extractRetryInfoFromBody(response);
-                  const serverRetryMs = bodyInfo.retryDelayMs ?? headerRetryMs;
-                  const quotaKey = headerStyleToQuotaKey(headerStyle, family);
-                  const { attempt, delayMs, isDuplicate } = getRateLimitBackoff(account.index, quotaKey, serverRetryMs);
-
-                  const waitTimeFormatted = formatWaitTime(delayMs);
-                  const isCapacityExhausted =
-                    bodyInfo.reason === "MODEL_CAPACITY_EXHAUSTED" ||
-                    (typeof bodyInfo.message === "string" && bodyInfo.message.toLowerCase().includes("no capacity"));
-
-                  pushDebug(
-                    `429 idx=${account.index} email=${account.email ?? ""} family=${family} delayMs=${delayMs} attempt=${attempt}`,
-                  );
-                  if (bodyInfo.message) {
-                    pushDebug(`429 message=${bodyInfo.message}`);
-                  }
-                  if (bodyInfo.quotaResetTime) {
-                    pushDebug(`429 quotaResetTime=${bodyInfo.quotaResetTime}`);
-                  }
-                  if (bodyInfo.reason) {
-                    pushDebug(`429 reason=${bodyInfo.reason}`);
-                  }
-
-                   logRateLimitEvent(
-                    account.index,
-                    account.email,
-                    family,
-                    response.status,
-                    delayMs,
-                    bodyInfo,
-                  );
-
-                  await logResponseBody(debugContext, response, 429);
-
-                  if (isCapacityExhausted) {
-                    accountManager.markRateLimited(account, delayMs, family, headerStyle, model);
-                    
-                    // For Gemini, try prioritized Antigravity across ALL accounts first
-                    if (family === "gemini" && headerStyle === "antigravity") {
-                      if (hasOtherAccountWithAntigravity(account)) {
-                        pushDebug(`capacity exhausted on account ${account.index}, but available on others. Switching account.`);
-                        shouldSwitchAccount = true;
-                        break;
-                      }
+              if (accessTokenExpired(authRecord)) {
+                try {
+                  const refreshed = await refreshAccessToken(authRecord, client, providerId);
+                  if (!refreshed) {
+                    const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
+                    lastError = new Error("Antigravity token refresh failed");
+                    if (shouldCooldown) {
+                      accountManager.markAccountCoolingDown(account, cooldownMs, "auth-failure");
+                      accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
+                      pushDebug(`token-refresh-failed: cooldown ${cooldownMs}ms after ${failures} failures`);
                     }
-
-                    await showToast(
-                      `Model capacity exhausted for ${family}. Retrying in ${waitTimeFormatted} (attempt ${attempt})...`,
-                      "warning",
-                    );
-                    await sleep(delayMs, abortSignal);
                     continue;
                   }
-                  
-                  const accountLabel = account.email || `Account ${account.index + 1}`;
-
-                  // Short retry: if delay is small, just wait and retry same account
-                  if (delayMs <= SHORT_RETRY_THRESHOLD_MS) {
-                    await showToast(`Rate limited. Retrying in ${waitTimeFormatted} (attempt ${attempt})...`, "warning");
-                    await sleep(delayMs, abortSignal);
-                    continue;
-                  }
-
-
-                  // Mark this header style as rate-limited for this account
-                  accountManager.markRateLimited(account, delayMs, family, headerStyle, model);
-
+                  resetAccountFailureState(account.index);
+                  accountManager.updateFromAuth(account, refreshed);
+                  authRecord = refreshed;
                   try {
                     await accountManager.saveToDisk();
                   } catch (error) {
-                    log.error("Failed to persist rate-limit state", { error: String(error) });
+                    log.error("Failed to persist refreshed auth", { error: String(error) });
                   }
-
-                  // For Gemini, try prioritized Antigravity across ALL accounts first
-                  if (family === "gemini") {
-                    if (headerStyle === "antigravity") {
-                      // Check if any other account has Antigravity quota for this model
-                      if (hasOtherAccountWithAntigravity(account)) {
-                        pushDebug(`antigravity exhausted on account ${account.index}, but available on others. Switching account.`);
-                        shouldSwitchAccount = true;
-                        break;
-                      }
-
-                      // All accounts exhausted for Antigravity on THIS model.
-                      // Before falling back to gemini-cli, check if it's the last option (automatic fallback)
-                      if (config.quota_fallback && !explicitQuota) {
-                        const alternateStyle = accountManager.getAvailableHeaderStyle(account, family, model);
-                        if (alternateStyle && alternateStyle !== headerStyle) {
-                          const safeModelName = model || "this model";
-                          await showToast(
-                            `Antigravity quota exhausted for ${safeModelName}. Switching to Gemini CLI quota... Tip: Other Gemini models may still have quota.`,
-                            "warning"
-                          );
-                          headerStyle = alternateStyle;
-                          pushDebug(`quota fallback: ${headerStyle}`);
-                          continue; // Retry with new headerStyle
-                        }
+                } catch (error) {
+                  if (error instanceof AntigravityTokenRefreshError && error.code === "invalid_grant") {
+                    const removed = accountManager.removeAccount(account);
+                    if (removed) {
+                      log.warn("Removed revoked account from pool - reauthenticate via `opencode auth login`");
+                      try {
+                        await accountManager.saveToDisk();
+                      } catch (persistError) {
+                        log.error("Failed to persist revoked account removal", { error: String(persistError) });
                       }
                     }
-                  }
 
-                  const quotaName = headerStyle === "antigravity" ? "Antigravity" : "Gemini CLI";
-
-                  if (accountCount > 1) {
-                    const quotaMsg = bodyInfo.quotaResetTime 
-                      ? ` (quota resets ${bodyInfo.quotaResetTime})`
-                      : ` (retry in ${waitTimeFormatted})`;
-                    await showToast(`Rate limited on ${quotaName} quota for ${accountLabel}${quotaMsg}. Switching account...`, "warning");
-                    
-                    lastFailure = {
-                      response,
-                      streaming: prepared.streaming,
-                      debugContext,
-                      requestedModel: prepared.requestedModel,
-                      projectId: prepared.projectId,
-                      endpoint: prepared.endpoint,
-                      effectiveModel: prepared.effectiveModel,
-                      sessionId: prepared.sessionId,
-                      toolDebugMissing: prepared.toolDebugMissing,
-                      toolDebugSummary: prepared.toolDebugSummary,
-                      toolDebugPayload: prepared.toolDebugPayload,
-                    };
-                    shouldSwitchAccount = true;
-                    break;
-                  } else {
-                    const quotaMsg = bodyInfo.quotaResetTime 
-                      ? `Quota resets ${bodyInfo.quotaResetTime}`
-                      : `Waiting ${waitTimeFormatted}`;
-                    await showToast(`Rate limited. ${quotaMsg} (attempt ${attempt})...`, "warning");
-                    
-                    lastFailure = {
-                      response,
-                      streaming: prepared.streaming,
-                      debugContext,
-                      requestedModel: prepared.requestedModel,
-                      projectId: prepared.projectId,
-                      endpoint: prepared.endpoint,
-                      effectiveModel: prepared.effectiveModel,
-                      sessionId: prepared.sessionId,
-                      toolDebugMissing: prepared.toolDebugMissing,
-                      toolDebugSummary: prepared.toolDebugSummary,
-                      toolDebugPayload: prepared.toolDebugPayload,
-                    };
-                    
-                    await sleep(delayMs, abortSignal);
-                    shouldSwitchAccount = true;
-                    break;
-                  }
-                }
-
-                // Success - reset rate limit backoff state for this quota
-                const quotaKey = headerStyleToQuotaKey(headerStyle, family);
-                resetRateLimitState(account.index, quotaKey);
-                resetAccountFailureState(account.index);
-
-                const shouldRetryEndpoint = (
-                  response.status === 403 ||
-                  response.status === 404 ||
-                  response.status >= 500
-                );
-
-                if (shouldRetryEndpoint) {
-                  await logResponseBody(debugContext, response, response.status);
-                }
-
-                if (shouldRetryEndpoint && i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length - 1) {
-                  lastFailure = {
-                    response,
-                    streaming: prepared.streaming,
-                    debugContext,
-                    requestedModel: prepared.requestedModel,
-                    projectId: prepared.projectId,
-                    endpoint: prepared.endpoint,
-                    effectiveModel: prepared.effectiveModel,
-                    sessionId: prepared.sessionId,
-                    toolDebugMissing: prepared.toolDebugMissing,
-                    toolDebugSummary: prepared.toolDebugSummary,
-                    toolDebugPayload: prepared.toolDebugPayload,
-                  };
-                  continue;
-                }
-
-                // Success or non-retryable error - return the response
-                logAntigravityDebugResponse(debugContext, response, {
-                  note: response.ok ? "Success" : `Error ${response.status}`,
-                });
-                if (!response.ok) {
-                  await logResponseBody(debugContext, response, response.status);
-                  
-                  // Handle 400 "Prompt too long" with synthetic response to avoid session lock
-                  if (response.status === 400) {
-                    const cloned = response.clone();
-                    const bodyText = await cloned.text();
-                    if (bodyText.includes("Prompt is too long") || bodyText.includes("prompt_too_long")) {
-                      if (!quietMode) {
-                        await showToast(
-                          "Context too long - use /compact to reduce size",
-                          "warning"
-                        );
+                    if (accountManager.getAccountCount() === 0) {
+                      try {
+                        await client.auth.set({
+                          path: { id: providerId },
+                          body: { type: "oauth", refresh: "", access: "", expires: 0 },
+                        });
+                      } catch (storeError) {
+                        log.error("Failed to clear stored Antigravity OAuth credentials", { error: String(storeError) });
                       }
-                      const errorMessage = `[Antigravity Error] Context is too long for this model.\n\nPlease use /compact to reduce context size, then retry your request.\n\nAlternatively, you can:\n- Use /clear to start fresh\n- Use /undo to remove recent messages\n- Switch to a model with larger context window`;
-                      return createSyntheticErrorResponse(errorMessage, prepared.requestedModel);
-                    }
-                  }
-                }
-                
-                // Empty response retry logic (ported from LLM-API-Key-Proxy)
-                // For non-streaming responses, check if the response body is empty
-                // and retry if so (up to config.empty_response_max_attempts times)
-                if (response.ok && !prepared.streaming) {
-                  const maxAttempts = config.empty_response_max_attempts ?? 4;
-                  const retryDelayMs = config.empty_response_retry_delay_ms ?? 2000;
-                  
-                  // Clone to check body without consuming original
-                  const clonedForCheck = response.clone();
-                  const bodyText = await clonedForCheck.text();
-                  
-                  if (isEmptyResponseBody(bodyText)) {
-                    // Track empty response attempts per request
-                    const emptyAttemptKey = `${prepared.sessionId ?? "none"}:${prepared.effectiveModel ?? "unknown"}`;
-                    const currentAttempts = (emptyResponseAttempts.get(emptyAttemptKey) ?? 0) + 1;
-                    emptyResponseAttempts.set(emptyAttemptKey, currentAttempts);
-                    
-                    pushDebug(`empty-response: attempt ${currentAttempts}/${maxAttempts}`);
-                    
-                    if (currentAttempts < maxAttempts) {
-                      await showToast(
-                        `Empty response received. Retrying (${currentAttempts}/${maxAttempts})...`,
-                        "warning"
+
+                      throw new Error(
+                        "All Antigravity accounts have invalid refresh tokens. Run `opencode auth login` and reauthenticate.",
                       );
-                      await sleep(retryDelayMs, abortSignal);
-                      continue; // Retry the endpoint loop
                     }
-                    
-                    // Clean up and throw after max attempts
-                    emptyResponseAttempts.delete(emptyAttemptKey);
-                    throw new EmptyResponseError(
-                      "antigravity",
-                      prepared.effectiveModel ?? "unknown",
-                      currentAttempts,
-                    );
-                  }
-                  
-                  // Clean up successful attempt tracking
-                  const emptyAttemptKeyClean = `${prepared.sessionId ?? "none"}:${prepared.effectiveModel ?? "unknown"}`;
-                  emptyResponseAttempts.delete(emptyAttemptKeyClean);
-                }
-                
-                const transformedResponse = await transformAntigravityResponse(
-                  response,
-                  prepared.streaming,
-                  debugContext,
-                  prepared.requestedModel,
-                  prepared.projectId,
-                  prepared.endpoint,
-                  prepared.effectiveModel,
-                  prepared.sessionId,
-                  prepared.toolDebugMissing,
-                  prepared.toolDebugSummary,
-                  prepared.toolDebugPayload,
-                  debugLines,
-                );
 
-                // Check for context errors and show appropriate toast
-                const contextError = transformedResponse.headers.get("x-antigravity-context-error");
-                if (contextError && !quietMode) {
-                  if (contextError === "prompt_too_long") {
-                    await showToast(
-                      "Context too long - use /compact to reduce size, or trim your request",
-                      "warning"
-                    );
-                  } else if (contextError === "tool_pairing") {
-                    await showToast(
-                      "Tool call/result mismatch - use /compact to fix, or /undo last message",
-                      "warning"
-                    );
-                  }
-                }
-
-                return transformedResponse;
-              } catch (error) {
-                // Handle recoverable thinking errors - retry with forced recovery
-                if (error instanceof Error && error.message === "THINKING_RECOVERY_NEEDED") {
-                  // Only retry once with forced recovery to avoid infinite loops
-                  if (!forceThinkingRecovery) {
-                    pushDebug("thinking-recovery: API error detected, retrying with forced recovery");
-                    forceThinkingRecovery = true;
-                    i = -1; // Will become 0 after loop increment, restart endpoint loop
+                    lastError = error;
                     continue;
                   }
-                  
-                  // Already tried with forced recovery, give up and return error
-                  const recoveryError = error as any;
-                  const originalError = recoveryError.originalError || { error: { message: "Thinking recovery triggered" } };
-                  
-                  const recoveryMessage = `${originalError.error?.message || "Session recovery failed"}\n\n[RECOVERY] Thinking block corruption could not be resolved. Try starting a new session.`;
-                  
-                  return new Response(JSON.stringify({
-                    type: "error",
-                    error: {
-                      type: "unrecoverable_error",
-                      message: recoveryMessage
-                    }
-                  }), {
-                    status: 400,
-                    headers: { "Content-Type": "application/json" }
-                  });
-                }
 
-                if (i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length - 1) {
+                  const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
                   lastError = error instanceof Error ? error : new Error(String(error));
+                  if (shouldCooldown) {
+                    accountManager.markAccountCoolingDown(account, cooldownMs, "auth-failure");
+                    accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
+                    pushDebug(`token-refresh-error: cooldown ${cooldownMs}ms after ${failures} failures`);
+                  }
                   continue;
                 }
+              }
 
-                // All endpoints failed for this account - track failure and try next account
+              const accessToken = authRecord.access;
+              if (!accessToken) {
+                lastError = new Error("Missing access token");
+                if (accountCount <= 1) {
+                  throw lastError;
+                }
+                continue;
+              }
+
+              let projectContext: ProjectContextResult;
+              try {
+                projectContext = await ensureProjectContext(authRecord);
+                resetAccountFailureState(account.index);
+              } catch (error) {
                 const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
                 lastError = error instanceof Error ? error : new Error(String(error));
                 if (shouldCooldown) {
-                  accountManager.markAccountCoolingDown(account, cooldownMs, "network-error");
-                  accountManager.markRateLimited(account, cooldownMs, family, headerStyle, model);
-                  pushDebug(`endpoint-error: cooldown ${cooldownMs}ms after ${failures} failures`);
+                  accountManager.markAccountCoolingDown(account, cooldownMs, "project-error");
+                  accountManager.markRateLimited(account, cooldownMs, family, "antigravity", model);
+                  pushDebug(`project-context-error: cooldown ${cooldownMs}ms after ${failures} failures`);
                 }
-                shouldSwitchAccount = true;
-                break;
+                continue;
               }
-            }
-            } // end headerStyleLoop
-            
-            if (shouldSwitchAccount) {
-              // Avoid tight retry loops when there's only one account.
-              if (accountCount <= 1) {
-                if (lastFailure) {
-                  return transformAntigravityResponse(
-                    lastFailure.response,
-                    lastFailure.streaming,
-                    lastFailure.debugContext,
-                    lastFailure.requestedModel,
-                    lastFailure.projectId,
-                    lastFailure.endpoint,
-                    lastFailure.effectiveModel,
-                    lastFailure.sessionId,
-                    lastFailure.toolDebugMissing,
-                    lastFailure.toolDebugSummary,
-                    lastFailure.toolDebugPayload,
-                    debugLines,
+
+              if (projectContext.auth !== authRecord) {
+                accountManager.updateFromAuth(account, projectContext.auth);
+                authRecord = projectContext.auth;
+                try {
+                  await accountManager.saveToDisk();
+                } catch (error) {
+                  log.error("Failed to persist project context", { error: String(error) });
+                }
+              }
+
+              const runThinkingWarmup = async (
+                prepared: ReturnType<typeof prepareAntigravityRequest>,
+                projectId: string,
+              ): Promise<void> => {
+                if (!prepared.needsSignedThinkingWarmup || !prepared.sessionId) {
+                  return;
+                }
+
+                if (!trackWarmupAttempt(prepared.sessionId)) {
+                  return;
+                }
+
+                const warmupBody = buildThinkingWarmupBody(
+                  typeof prepared.init.body === "string" ? prepared.init.body : undefined,
+                  Boolean(prepared.effectiveModel?.toLowerCase().includes("claude") && prepared.effectiveModel?.toLowerCase().includes("thinking")),
+                );
+                if (!warmupBody) {
+                  return;
+                }
+
+                const warmupUrl = toWarmupStreamUrl(prepared.request);
+                const warmupHeaders = new Headers(prepared.init.headers ?? {});
+                warmupHeaders.set("accept", "text/event-stream");
+
+                const warmupInit: RequestInit = {
+                  ...prepared.init,
+                  method: prepared.init.method ?? "POST",
+                  headers: warmupHeaders,
+                  body: warmupBody,
+                };
+
+                const warmupDebugContext = startAntigravityDebugRequest({
+                  originalUrl: warmupUrl,
+                  resolvedUrl: warmupUrl,
+                  method: warmupInit.method,
+                  headers: warmupHeaders,
+                  body: warmupBody,
+                  streaming: true,
+                  projectId,
+                });
+
+                try {
+                  pushDebug("thinking-warmup: start");
+                  const warmupResponse = await fetch(warmupUrl, warmupInit);
+                  const transformed = await transformAntigravityResponse(
+                    warmupResponse,
+                    true,
+                    warmupDebugContext,
+                    prepared.requestedModel,
+                    projectId,
+                    warmupUrl,
+                    prepared.effectiveModel,
+                    prepared.sessionId,
+                  );
+                  await transformed.text();
+                  markWarmupSuccess(prepared.sessionId);
+                  pushDebug("thinking-warmup: done");
+                } catch (error) {
+                  clearWarmupAttempt(prepared.sessionId);
+                  pushDebug(
+                    `thinking-warmup: failed ${error instanceof Error ? error.message : String(error)}`,
                   );
                 }
+              };
 
-                throw lastError || new Error("All Antigravity endpoints failed");
-              }
+              // Try endpoint fallbacks with single header style based on model suffix
+              let shouldSwitchAccount = false;
 
-              continue;
-            }
+              // Determine header style from model suffix:
+              // - Models with :antigravity suffix -> use Antigravity quota
+              // - Models without suffix (default) -> use Gemini CLI quota
+              // - Claude models -> always use Antigravity
+              let headerStyle = getHeaderStyleFromUrl(urlString, family);
+              const explicitQuota = isExplicitQuotaFromUrl(urlString);
+              pushDebug(`headerStyle=${headerStyle} explicit=${explicitQuota}`);
 
-            // If we get here without returning, something went wrong
-            if (lastFailure) {
-              return transformAntigravityResponse(
-                lastFailure.response,
-                lastFailure.streaming,
-                lastFailure.debugContext,
-                lastFailure.requestedModel,
-                lastFailure.projectId,
-                lastFailure.endpoint,
-                lastFailure.effectiveModel,
-                lastFailure.sessionId,
-                lastFailure.toolDebugMissing,
-                lastFailure.toolDebugSummary,
-                lastFailure.toolDebugPayload,
-                debugLines,
-              );
-            }
-
-            throw lastError || new Error("All Antigravity accounts failed");
-          }
-        },
-      };
-    },
-    methods: [
-      {
-        label: "OAuth with Google (Antigravity)",
-        type: "oauth",
-        authorize: async (inputs?: Record<string, string>) => {
-          const isHeadless = !!(
-            process.env.SSH_CONNECTION ||
-            process.env.SSH_CLIENT ||
-            process.env.SSH_TTY ||
-            process.env.OPENCODE_HEADLESS
-          );
-
-          // CLI flow (`opencode auth login`) passes an inputs object.
-          if (inputs) {
-            const accounts: Array<Extract<AntigravityTokenExchangeResult, { type: "success" }>> = [];
-            const noBrowser = inputs.noBrowser === "true" || inputs["no-browser"] === "true";
-            const useManualMode = noBrowser || shouldSkipLocalServer();
-
-            // Check for existing accounts and prompt user for login mode
-            let startFresh = true;
-            const existingStorage = await loadAccounts();
-            if (existingStorage && existingStorage.accounts.length > 0) {
-              const existingAccounts = existingStorage.accounts.map((acc, idx) => ({
-                email: acc.email,
-                index: idx,
-              }));
-              
-              const loginMode = await promptLoginMode(existingAccounts);
-              startFresh = loginMode === "fresh";
-              
-              if (startFresh) {
-                console.log("\nStarting fresh - existing accounts will be replaced.\n");
-              } else {
-                console.log("\nAdding to existing accounts.\n");
-              }
-            }
-
-            while (accounts.length < MAX_OAUTH_ACCOUNTS) {
-              console.log(`\n=== Antigravity OAuth (Account ${accounts.length + 1}) ===`);
-
-              const projectId = await promptProjectId();
-
-              const result = await (async (): Promise<AntigravityTokenExchangeResult> => {
-                const authorization = await authorizeAntigravity(projectId);
-                const fallbackState = getStateFromAuthorizationUrl(authorization.url);
-
-                console.log("\nOAuth URL:\n" + authorization.url + "\n");
-
-                if (useManualMode) {
-                  const browserOpened = await openBrowser(authorization.url);
-                  if (!browserOpened) {
-                    console.log("Could not open browser automatically.");
-                    console.log("Please open the URL above manually in your local browser.\n");
+              // Check if this header style is rate-limited for this account
+              if (accountManager.isRateLimitedForHeaderStyle(account, family, headerStyle, model)) {
+                // Quota fallback: try alternate quota on same account (if enabled and not explicit)
+                if (config.quota_fallback && !explicitQuota && family === "gemini") {
+                  const alternateStyle = accountManager.getAvailableHeaderStyle(account, family, model);
+                  if (alternateStyle && alternateStyle !== headerStyle) {
+                    const quotaName = headerStyle === "gemini-cli" ? "Gemini CLI" : "Antigravity";
+                    const altQuotaName = alternateStyle === "gemini-cli" ? "Gemini CLI" : "Antigravity";
+                    if (!quietMode) {
+                      await showToast(
+                        `${quotaName} quota exhausted, using ${altQuotaName} quota`,
+                        "warning"
+                      );
+                    }
+                    headerStyle = alternateStyle;
+                    pushDebug(`quota fallback: ${headerStyle}`);
+                  } else {
+                    shouldSwitchAccount = true;
                   }
+                } else {
+                  shouldSwitchAccount = true;
+                }
+              }
+
+              while (!shouldSwitchAccount) {
+
+                // Flag to force thinking recovery on retry after API error
+                let forceThinkingRecovery = false;
+
+                for (let i = 0; i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length; i++) {
+                  const currentEndpoint = ANTIGRAVITY_ENDPOINT_FALLBACKS[i];
+
+                  try {
+                    const prepared = prepareAntigravityRequest(
+                      input,
+                      init,
+                      accessToken,
+                      projectContext.effectiveProjectId,
+                      currentEndpoint,
+                      headerStyle,
+                      forceThinkingRecovery,
+                      {
+                        claudeToolHardening: config.claude_tool_hardening,
+                      },
+                    );
+
+                    // Show thinking recovery toast (respects quiet mode)
+                    if (!quietMode && prepared.thinkingRecoveryMessage) {
+                      await showToast(prepared.thinkingRecoveryMessage, "warning");
+                    }
+
+                    const originalUrl = toUrlString(input);
+                    const resolvedUrl = toUrlString(prepared.request);
+                    pushDebug(`endpoint=${currentEndpoint}`);
+                    pushDebug(`resolved=${resolvedUrl}`);
+                    const debugContext = startAntigravityDebugRequest({
+                      originalUrl,
+                      resolvedUrl,
+                      method: prepared.init.method,
+                      headers: prepared.init.headers,
+                      body: prepared.init.body,
+                      streaming: prepared.streaming,
+                      projectId: projectContext.effectiveProjectId,
+                    });
+
+                    await runThinkingWarmup(prepared, projectContext.effectiveProjectId);
+
+                    const response = await fetch(prepared.request, prepared.init);
+                    pushDebug(`status=${response.status} ${response.statusText}`);
+
+
+
+
+                    // Handle 429 rate limit with improved logic
+                    if (response.status === 429) {
+                      const headerRetryMs = retryAfterMsFromResponse(response);
+                      const bodyInfo = await extractRetryInfoFromBody(response);
+                      const serverRetryMs = bodyInfo.retryDelayMs ?? headerRetryMs;
+                      const quotaKey = headerStyleToQuotaKey(headerStyle, family);
+                      const { attempt, delayMs, isDuplicate } = getRateLimitBackoff(account.index, quotaKey, serverRetryMs);
+
+                      const waitTimeFormatted = formatWaitTime(delayMs);
+                      const isCapacityExhausted =
+                        bodyInfo.reason === "MODEL_CAPACITY_EXHAUSTED" ||
+                        (typeof bodyInfo.message === "string" && bodyInfo.message.toLowerCase().includes("no capacity"));
+
+                      pushDebug(
+                        `429 idx=${account.index} email=${account.email ?? ""} family=${family} delayMs=${delayMs} attempt=${attempt}`,
+                      );
+                      if (bodyInfo.message) {
+                        pushDebug(`429 message=${bodyInfo.message}`);
+                      }
+                      if (bodyInfo.quotaResetTime) {
+                        pushDebug(`429 quotaResetTime=${bodyInfo.quotaResetTime}`);
+                      }
+                      if (bodyInfo.reason) {
+                        pushDebug(`429 reason=${bodyInfo.reason}`);
+                      }
+
+                      logRateLimitEvent(
+                        account.index,
+                        account.email,
+                        family,
+                        response.status,
+                        delayMs,
+                        bodyInfo,
+                      );
+
+                      await logResponseBody(debugContext, response, 429);
+
+                      if (isCapacityExhausted) {
+                        accountManager.markRateLimited(account, delayMs, family, headerStyle, model);
+
+                        // For Gemini, try prioritized Antigravity across ALL accounts first
+                        if (family === "gemini" && headerStyle === "antigravity") {
+                          if (hasOtherAccountWithAntigravity(account)) {
+                            pushDebug(`capacity exhausted on account ${account.index}, but available on others. Switching account.`);
+                            shouldSwitchAccount = true;
+                            break;
+                          }
+                        }
+
+                        await showToast(
+                          `Model capacity exhausted for ${family}. Retrying in ${waitTimeFormatted} (attempt ${attempt})...`,
+                          "warning",
+                        );
+                        await sleep(delayMs, abortSignal);
+                        continue;
+                      }
+
+                      const accountLabel = account.email || `Account ${account.index + 1}`;
+
+                      // Short retry: if delay is small, just wait and retry same account
+                      if (delayMs <= SHORT_RETRY_THRESHOLD_MS) {
+                        await showToast(`Rate limited. Retrying in ${waitTimeFormatted} (attempt ${attempt})...`, "warning");
+                        await sleep(delayMs, abortSignal);
+                        continue;
+                      }
+
+
+                      // Mark this header style as rate-limited for this account
+                      accountManager.markRateLimited(account, delayMs, family, headerStyle, model);
+
+                      try {
+                        await accountManager.saveToDisk();
+                      } catch (error) {
+                        log.error("Failed to persist rate-limit state", { error: String(error) });
+                      }
+
+                      // For Gemini, try prioritized Antigravity across ALL accounts first
+                      if (family === "gemini") {
+                        if (headerStyle === "antigravity") {
+                          // Check if any other account has Antigravity quota for this model
+                          if (hasOtherAccountWithAntigravity(account)) {
+                            pushDebug(`antigravity exhausted on account ${account.index}, but available on others. Switching account.`);
+                            shouldSwitchAccount = true;
+                            break;
+                          }
+
+                          // All accounts exhausted for Antigravity on THIS model.
+                          // Before falling back to gemini-cli, check if it's the last option (automatic fallback)
+                          if (config.quota_fallback && !explicitQuota) {
+                            const alternateStyle = accountManager.getAvailableHeaderStyle(account, family, model);
+                            if (alternateStyle && alternateStyle !== headerStyle) {
+                              const safeModelName = model || "this model";
+                              await showToast(
+                                `Antigravity quota exhausted for ${safeModelName}. Switching to Gemini CLI quota... Tip: Other Gemini models may still have quota.`,
+                                "warning"
+                              );
+                              headerStyle = alternateStyle;
+                              pushDebug(`quota fallback: ${headerStyle}`);
+                              continue; // Retry with new headerStyle
+                            }
+                          }
+                        }
+                      }
+
+                      const quotaName = headerStyle === "antigravity" ? "Antigravity" : "Gemini CLI";
+
+                      if (accountCount > 1) {
+                        const quotaMsg = bodyInfo.quotaResetTime
+                          ? ` (quota resets ${bodyInfo.quotaResetTime})`
+                          : ` (retry in ${waitTimeFormatted})`;
+                        await showToast(`Rate limited on ${quotaName} quota for ${accountLabel}${quotaMsg}. Switching account...`, "warning");
+
+                        lastFailure = {
+                          response,
+                          streaming: prepared.streaming,
+                          debugContext,
+                          requestedModel: prepared.requestedModel,
+                          projectId: prepared.projectId,
+                          endpoint: prepared.endpoint,
+                          effectiveModel: prepared.effectiveModel,
+                          sessionId: prepared.sessionId,
+                          toolDebugMissing: prepared.toolDebugMissing,
+                          toolDebugSummary: prepared.toolDebugSummary,
+                          toolDebugPayload: prepared.toolDebugPayload,
+                        };
+                        shouldSwitchAccount = true;
+                        break;
+                      } else {
+                        const quotaMsg = bodyInfo.quotaResetTime
+                          ? `Quota resets ${bodyInfo.quotaResetTime}`
+                          : `Waiting ${waitTimeFormatted}`;
+                        await showToast(`Rate limited. ${quotaMsg} (attempt ${attempt})...`, "warning");
+
+                        lastFailure = {
+                          response,
+                          streaming: prepared.streaming,
+                          debugContext,
+                          requestedModel: prepared.requestedModel,
+                          projectId: prepared.projectId,
+                          endpoint: prepared.endpoint,
+                          effectiveModel: prepared.effectiveModel,
+                          sessionId: prepared.sessionId,
+                          toolDebugMissing: prepared.toolDebugMissing,
+                          toolDebugSummary: prepared.toolDebugSummary,
+                          toolDebugPayload: prepared.toolDebugPayload,
+                        };
+
+                        await sleep(delayMs, abortSignal);
+                        shouldSwitchAccount = true;
+                        break;
+                      }
+                    }
+
+                    // Success - reset rate limit backoff state for this quota
+                    const quotaKey = headerStyleToQuotaKey(headerStyle, family);
+                    resetRateLimitState(account.index, quotaKey);
+                    resetAccountFailureState(account.index);
+
+                    const shouldRetryEndpoint = (
+                      response.status === 403 ||
+                      response.status === 404 ||
+                      response.status >= 500
+                    );
+
+                    if (shouldRetryEndpoint) {
+                      await logResponseBody(debugContext, response, response.status);
+                    }
+
+                    if (shouldRetryEndpoint && i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length - 1) {
+                      lastFailure = {
+                        response,
+                        streaming: prepared.streaming,
+                        debugContext,
+                        requestedModel: prepared.requestedModel,
+                        projectId: prepared.projectId,
+                        endpoint: prepared.endpoint,
+                        effectiveModel: prepared.effectiveModel,
+                        sessionId: prepared.sessionId,
+                        toolDebugMissing: prepared.toolDebugMissing,
+                        toolDebugSummary: prepared.toolDebugSummary,
+                        toolDebugPayload: prepared.toolDebugPayload,
+                      };
+                      continue;
+                    }
+
+                    // Success or non-retryable error - return the response
+                    logAntigravityDebugResponse(debugContext, response, {
+                      note: response.ok ? "Success" : `Error ${response.status}`,
+                    });
+                    if (!response.ok) {
+                      await logResponseBody(debugContext, response, response.status);
+
+                      // Handle 400 "Prompt too long" with synthetic response to avoid session lock
+                      if (response.status === 400) {
+                        const cloned = response.clone();
+                        const bodyText = await cloned.text();
+                        if (bodyText.includes("Prompt is too long") || bodyText.includes("prompt_too_long")) {
+                          if (!quietMode) {
+                            await showToast(
+                              "Context too long - use /compact to reduce size",
+                              "warning"
+                            );
+                          }
+                          const errorMessage = `[Antigravity Error] Context is too long for this model.\n\nPlease use /compact to reduce context size, then retry your request.\n\nAlternatively, you can:\n- Use /clear to start fresh\n- Use /undo to remove recent messages\n- Switch to a model with larger context window`;
+                          return createSyntheticErrorResponse(errorMessage, prepared.requestedModel);
+                        }
+                      }
+
+                      // fresh accounts sometimes get 403s bc google hasnt provisioned them yet
+                      // just show a friendly msg so ppl know to wait a bit
+                      if (response.status === 403) {
+                        const cloned = response.clone();
+                        const bodyText = await cloned.text();
+                        if (isCloudAICompanionPermissionDenied(bodyText)) {
+                          if (!quietMode) {
+                            await showToast(
+                              getProvisioningErrorMessage(),
+                              "warning"
+                            );
+                          }
+                        }
+                      }
+                    }
+
+                    // Empty response retry logic (ported from LLM-API-Key-Proxy)
+                    // For non-streaming responses, check if the response body is empty
+                    // and retry if so (up to config.empty_response_max_attempts times)
+                    if (response.ok && !prepared.streaming) {
+                      const maxAttempts = config.empty_response_max_attempts ?? 4;
+                      const retryDelayMs = config.empty_response_retry_delay_ms ?? 2000;
+
+                      // Clone to check body without consuming original
+                      const clonedForCheck = response.clone();
+                      const bodyText = await clonedForCheck.text();
+
+                      if (isEmptyResponseBody(bodyText)) {
+                        // Track empty response attempts per request
+                        const emptyAttemptKey = `${prepared.sessionId ?? "none"}:${prepared.effectiveModel ?? "unknown"}`;
+                        const currentAttempts = (emptyResponseAttempts.get(emptyAttemptKey) ?? 0) + 1;
+                        emptyResponseAttempts.set(emptyAttemptKey, currentAttempts);
+
+                        pushDebug(`empty-response: attempt ${currentAttempts}/${maxAttempts}`);
+
+                        if (currentAttempts < maxAttempts) {
+                          await showToast(
+                            `Empty response received. Retrying (${currentAttempts}/${maxAttempts})...`,
+                            "warning"
+                          );
+                          await sleep(retryDelayMs, abortSignal);
+                          continue; // Retry the endpoint loop
+                        }
+
+                        // Clean up and throw after max attempts
+                        emptyResponseAttempts.delete(emptyAttemptKey);
+                        throw new EmptyResponseError(
+                          "antigravity",
+                          prepared.effectiveModel ?? "unknown",
+                          currentAttempts,
+                        );
+                      }
+
+                      // Clean up successful attempt tracking
+                      const emptyAttemptKeyClean = `${prepared.sessionId ?? "none"}:${prepared.effectiveModel ?? "unknown"}`;
+                      emptyResponseAttempts.delete(emptyAttemptKeyClean);
+                    }
+
+                    const transformedResponse = await transformAntigravityResponse(
+                      response,
+                      prepared.streaming,
+                      debugContext,
+                      prepared.requestedModel,
+                      prepared.projectId,
+                      prepared.endpoint,
+                      prepared.effectiveModel,
+                      prepared.sessionId,
+                      prepared.toolDebugMissing,
+                      prepared.toolDebugSummary,
+                      prepared.toolDebugPayload,
+                      debugLines,
+                    );
+
+                    // Check for context errors and show appropriate toast
+                    const contextError = transformedResponse.headers.get("x-antigravity-context-error");
+                    if (contextError && !quietMode) {
+                      if (contextError === "prompt_too_long") {
+                        await showToast(
+                          "Context too long - use /compact to reduce size, or trim your request",
+                          "warning"
+                        );
+                      } else if (contextError === "tool_pairing") {
+                        await showToast(
+                          "Tool call/result mismatch - use /compact to fix, or /undo last message",
+                          "warning"
+                        );
+                      }
+                    }
+
+                    return transformedResponse;
+                  } catch (error) {
+                    // Handle recoverable thinking errors - retry with forced recovery
+                    if (error instanceof Error && error.message === "THINKING_RECOVERY_NEEDED") {
+                      // Only retry once with forced recovery to avoid infinite loops
+                      if (!forceThinkingRecovery) {
+                        pushDebug("thinking-recovery: API error detected, retrying with forced recovery");
+                        forceThinkingRecovery = true;
+                        i = -1; // Will become 0 after loop increment, restart endpoint loop
+                        continue;
+                      }
+
+                      // Already tried with forced recovery, give up and return error
+                      const recoveryError = error as any;
+                      const originalError = recoveryError.originalError || { error: { message: "Thinking recovery triggered" } };
+
+                      const recoveryMessage = `${originalError.error?.message || "Session recovery failed"}\n\n[RECOVERY] Thinking block corruption could not be resolved. Try starting a new session.`;
+
+                      return new Response(JSON.stringify({
+                        type: "error",
+                        error: {
+                          type: "unrecoverable_error",
+                          message: recoveryMessage
+                        }
+                      }), {
+                        status: 400,
+                        headers: { "Content-Type": "application/json" }
+                      });
+                    }
+
+                    if (i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length - 1) {
+                      lastError = error instanceof Error ? error : new Error(String(error));
+                      continue;
+                    }
+
+                    // All endpoints failed for this account - track failure and try next account
+                    const { failures, shouldCooldown, cooldownMs } = trackAccountFailure(account.index);
+                    lastError = error instanceof Error ? error : new Error(String(error));
+                    if (shouldCooldown) {
+                      accountManager.markAccountCoolingDown(account, cooldownMs, "network-error");
+                      accountManager.markRateLimited(account, cooldownMs, family, headerStyle, model);
+                      pushDebug(`endpoint-error: cooldown ${cooldownMs}ms after ${failures} failures`);
+                    }
+                    shouldSwitchAccount = true;
+                    break;
+                  }
+                }
+              } // end headerStyleLoop
+
+              if (shouldSwitchAccount) {
+                // Avoid tight retry loops when there's only one account.
+                if (accountCount <= 1) {
+                  if (lastFailure) {
+                    return transformAntigravityResponse(
+                      lastFailure.response,
+                      lastFailure.streaming,
+                      lastFailure.debugContext,
+                      lastFailure.requestedModel,
+                      lastFailure.projectId,
+                      lastFailure.endpoint,
+                      lastFailure.effectiveModel,
+                      lastFailure.sessionId,
+                      lastFailure.toolDebugMissing,
+                      lastFailure.toolDebugSummary,
+                      lastFailure.toolDebugPayload,
+                      debugLines,
+                    );
+                  }
+
+                  throw lastError || new Error("All Antigravity endpoints failed");
+                }
+
+                continue;
+              }
+
+              // If we get here without returning, something went wrong
+              if (lastFailure) {
+                return transformAntigravityResponse(
+                  lastFailure.response,
+                  lastFailure.streaming,
+                  lastFailure.debugContext,
+                  lastFailure.requestedModel,
+                  lastFailure.projectId,
+                  lastFailure.endpoint,
+                  lastFailure.effectiveModel,
+                  lastFailure.sessionId,
+                  lastFailure.toolDebugMissing,
+                  lastFailure.toolDebugSummary,
+                  lastFailure.toolDebugPayload,
+                  debugLines,
+                );
+              }
+
+              throw lastError || new Error("All Antigravity accounts failed");
+            }
+          },
+        };
+      },
+      methods: [
+        {
+          label: "OAuth with Google (Antigravity)",
+          type: "oauth",
+          authorize: async (inputs?: Record<string, string>) => {
+            const isHeadless = !!(
+              process.env.SSH_CONNECTION ||
+              process.env.SSH_CLIENT ||
+              process.env.SSH_TTY ||
+              process.env.OPENCODE_HEADLESS
+            );
+
+            // CLI flow (`opencode auth login`) passes an inputs object.
+            if (inputs) {
+              const accounts: Array<Extract<AntigravityTokenExchangeResult, { type: "success" }>> = [];
+              const noBrowser = inputs.noBrowser === "true" || inputs["no-browser"] === "true";
+              const useManualMode = noBrowser || shouldSkipLocalServer();
+
+              // Check for existing accounts and prompt user for login mode
+              let startFresh = true;
+              const existingStorage = await loadAccounts();
+              if (existingStorage && existingStorage.accounts.length > 0) {
+                const existingAccounts = existingStorage.accounts.map((acc, idx) => ({
+                  email: acc.email,
+                  index: idx,
+                }));
+
+                const loginMode = await promptLoginMode(existingAccounts);
+                startFresh = loginMode === "fresh";
+
+                if (startFresh) {
+                  console.log("\nStarting fresh - existing accounts will be replaced.\n");
+                } else {
+                  console.log("\nAdding to existing accounts.\n");
+                }
+              }
+
+              while (accounts.length < MAX_OAUTH_ACCOUNTS) {
+                console.log(`\n=== Antigravity OAuth (Account ${accounts.length + 1}) ===`);
+
+                const projectId = await promptProjectId();
+
+                const result = await (async (): Promise<AntigravityTokenExchangeResult> => {
+                  const authorization = await authorizeAntigravity(projectId);
+                  const fallbackState = getStateFromAuthorizationUrl(authorization.url);
+
+                  console.log("\nOAuth URL:\n" + authorization.url + "\n");
+
+                  if (useManualMode) {
+                    const browserOpened = await openBrowser(authorization.url);
+                    if (!browserOpened) {
+                      console.log("Could not open browser automatically.");
+                      console.log("Please open the URL above manually in your local browser.\n");
+                    }
+                    return promptManualOAuthInput(fallbackState);
+                  }
+
+                  let listener: OAuthListener | null = null;
+                  if (!isHeadless) {
+                    try {
+                      listener = await startOAuthListener();
+                    } catch {
+                      listener = null;
+                    }
+                  }
+
+                  if (!isHeadless) {
+                    await openBrowser(authorization.url);
+                  }
+
+                  if (listener) {
+                    try {
+                      const SOFT_TIMEOUT_MS = 30000;
+                      const callbackPromise = listener.waitForCallback();
+                      const timeoutPromise = new Promise<never>((_, reject) =>
+                        setTimeout(() => reject(new Error("SOFT_TIMEOUT")), SOFT_TIMEOUT_MS)
+                      );
+
+                      let callbackUrl: URL;
+                      try {
+                        callbackUrl = await Promise.race([callbackPromise, timeoutPromise]);
+                      } catch (err) {
+                        if (err instanceof Error && err.message === "SOFT_TIMEOUT") {
+                          console.log("\n⏳ Automatic callback not received after 30 seconds.");
+                          console.log("You can paste the redirect URL manually.\n");
+                          console.log("OAuth URL (in case you need it again):");
+                          console.log(authorization.url + "\n");
+
+                          try {
+                            await listener.close();
+                          } catch { }
+
+                          return promptManualOAuthInput(fallbackState);
+                        }
+                        throw err;
+                      }
+
+                      const params = extractOAuthCallbackParams(callbackUrl);
+                      if (!params) {
+                        return { type: "failed", error: "Missing code or state in callback URL" };
+                      }
+
+                      return exchangeAntigravity(params.code, params.state);
+                    } catch (error) {
+                      if (error instanceof Error && error.message !== "SOFT_TIMEOUT") {
+                        return {
+                          type: "failed",
+                          error: error.message,
+                        };
+                      }
+                      return {
+                        type: "failed",
+                        error: error instanceof Error ? error.message : "Unknown error",
+                      };
+                    } finally {
+                      try {
+                        await listener.close();
+                      } catch { }
+                    }
+                  }
+
                   return promptManualOAuthInput(fallbackState);
-                }
+                })();
 
-                let listener: OAuthListener | null = null;
-                if (!isHeadless) {
-                  try {
-                    listener = await startOAuthListener();
-                  } catch {
-                    listener = null;
+                if (result.type === "failed") {
+                  if (accounts.length === 0) {
+                    return {
+                      url: "",
+                      instructions: `Authentication failed: ${result.error}`,
+                      method: "auto",
+                      callback: async () => result,
+                    };
                   }
+
+                  console.warn(
+                    `[opencode-antigravity-auth] Skipping failed account ${accounts.length + 1}: ${result.error}`,
+                  );
+                  break;
                 }
 
-                if (!isHeadless) {
-                  await openBrowser(authorization.url);
+                accounts.push(result);
+
+                // Show toast for successful account authentication
+                try {
+                  await client.tui.showToast({
+                    body: {
+                      message: `Account ${accounts.length} authenticated${result.email ? ` (${result.email})` : ""}`,
+                      variant: "success",
+                    },
+                  });
+                } catch {
+                  // TUI may not be available in CLI mode
                 }
 
-                if (listener) {
+                try {
+                  // Use startFresh only on first account, subsequent accounts always append
+                  const isFirstAccount = accounts.length === 1;
+                  await persistAccountPool([result], isFirstAccount && startFresh);
+                } catch {
+                  // ignore
+                }
+
+                if (accounts.length >= MAX_OAUTH_ACCOUNTS) {
+                  break;
+                }
+
+                // Get the actual deduplicated account count from storage for the prompt
+                let currentAccountCount = accounts.length;
+                try {
+                  const currentStorage = await loadAccounts();
+                  if (currentStorage) {
+                    currentAccountCount = currentStorage.accounts.length;
+                  }
+                } catch {
+                  // Fall back to accounts.length if we can't read storage
+                }
+
+                const addAnother = await promptAddAnotherAccount(currentAccountCount);
+                if (!addAnother) {
+                  break;
+                }
+              }
+
+              const primary = accounts[0];
+              if (!primary) {
+                return {
+                  url: "",
+                  instructions: "Authentication cancelled",
+                  method: "auto",
+                  callback: async () => ({ type: "failed", error: "Authentication cancelled" }),
+                };
+              }
+
+              // Get the actual deduplicated account count from storage
+              let actualAccountCount = accounts.length;
+              try {
+                const finalStorage = await loadAccounts();
+                if (finalStorage) {
+                  actualAccountCount = finalStorage.accounts.length;
+                }
+              } catch {
+                // Fall back to accounts.length if we can't read storage
+              }
+
+              return {
+                url: "",
+                instructions: `Multi-account setup complete (${actualAccountCount} account(s)).`,
+                method: "auto",
+                callback: async (): Promise<AntigravityTokenExchangeResult> => primary,
+              };
+            }
+
+            // TUI flow (`/connect`) does not support per-account prompts.
+            // Default to adding new accounts (non-destructive).
+            // Users can run `opencode auth logout` first if they want a fresh start.
+            const projectId = "";
+
+            // Check existing accounts count for toast message
+            const existingStorage = await loadAccounts();
+            const existingCount = existingStorage?.accounts.length ?? 0;
+
+            const useManualFlow = isHeadless || shouldSkipLocalServer();
+
+            let listener: OAuthListener | null = null;
+            if (!useManualFlow) {
+              try {
+                listener = await startOAuthListener();
+              } catch {
+                listener = null;
+              }
+            }
+
+            const authorization = await authorizeAntigravity(projectId);
+            const fallbackState = getStateFromAuthorizationUrl(authorization.url);
+
+            if (!useManualFlow) {
+              const browserOpened = await openBrowser(authorization.url);
+              if (!browserOpened) {
+                listener?.close().catch(() => { });
+                listener = null;
+              }
+            }
+
+            if (listener) {
+              return {
+                url: authorization.url,
+                instructions:
+                  "Complete sign-in in your browser. We'll automatically detect the redirect back to localhost.",
+                method: "auto",
+                callback: async (): Promise<AntigravityTokenExchangeResult> => {
+                  const CALLBACK_TIMEOUT_MS = 30000;
                   try {
-                    const SOFT_TIMEOUT_MS = 30000;
                     const callbackPromise = listener.waitForCallback();
                     const timeoutPromise = new Promise<never>((_, reject) =>
-                      setTimeout(() => reject(new Error("SOFT_TIMEOUT")), SOFT_TIMEOUT_MS)
+                      setTimeout(() => reject(new Error("CALLBACK_TIMEOUT")), CALLBACK_TIMEOUT_MS),
                     );
 
                     let callbackUrl: URL;
                     try {
                       callbackUrl = await Promise.race([callbackPromise, timeoutPromise]);
                     } catch (err) {
-                      if (err instanceof Error && err.message === "SOFT_TIMEOUT") {
-                        console.log("\n⏳ Automatic callback not received after 30 seconds.");
-                        console.log("You can paste the redirect URL manually.\n");
-                        console.log("OAuth URL (in case you need it again):");
-                        console.log(authorization.url + "\n");
-                        
-                        try {
-                          await listener.close();
-                        } catch {}
-                        
-                        return promptManualOAuthInput(fallbackState);
+                      if (err instanceof Error && err.message === "CALLBACK_TIMEOUT") {
+                        return {
+                          type: "failed",
+                          error: "Callback timeout - please use CLI with --no-browser flag for manual input",
+                        };
                       }
                       throw err;
                     }
@@ -1686,14 +1876,31 @@ export const createAntigravityPlugin = (providerId: string) => async (
                       return { type: "failed", error: "Missing code or state in callback URL" };
                     }
 
-                    return exchangeAntigravity(params.code, params.state);
-                  } catch (error) {
-                    if (error instanceof Error && error.message !== "SOFT_TIMEOUT") {
-                      return {
-                        type: "failed",
-                        error: error.message,
-                      };
+                    const result = await exchangeAntigravity(params.code, params.state);
+                    if (result.type === "success") {
+                      try {
+                        await persistAccountPool([result], false);
+                      } catch {
+                      }
+
+                      const newTotal = existingCount + 1;
+                      const toastMessage = existingCount > 0
+                        ? `Added account${result.email ? ` (${result.email})` : ""} - ${newTotal} total`
+                        : `Authenticated${result.email ? ` (${result.email})` : ""}`;
+
+                      try {
+                        await client.tui.showToast({
+                          body: {
+                            message: toastMessage,
+                            variant: "success",
+                          },
+                        });
+                      } catch {
+                      }
                     }
+
+                    return result;
+                  } catch (error) {
                     return {
                       type: "failed",
                       error: error instanceof Error ? error.message : "Unknown error",
@@ -1701,252 +1908,62 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   } finally {
                     try {
                       await listener.close();
-                    } catch {}
+                    } catch {
+                    }
                   }
-                }
-
-                return promptManualOAuthInput(fallbackState);
-              })();
-
-              if (result.type === "failed") {
-                if (accounts.length === 0) {
-                  return {
-                    url: "",
-                    instructions: `Authentication failed: ${result.error}`,
-                    method: "auto",
-                    callback: async () => result,
-                  };
-                }
-
-                console.warn(
-                  `[opencode-antigravity-auth] Skipping failed account ${accounts.length + 1}: ${result.error}`,
-                );
-                break;
-              }
-
-              accounts.push(result);
-
-              // Show toast for successful account authentication
-              try {
-                await client.tui.showToast({
-                  body: {
-                    message: `Account ${accounts.length} authenticated${result.email ? ` (${result.email})` : ""}`,
-                    variant: "success",
-                  },
-                });
-              } catch {
-                // TUI may not be available in CLI mode
-              }
-
-              try {
-                // Use startFresh only on first account, subsequent accounts always append
-                const isFirstAccount = accounts.length === 1;
-                await persistAccountPool([result], isFirstAccount && startFresh);
-              } catch {
-                // ignore
-              }
-
-              if (accounts.length >= MAX_OAUTH_ACCOUNTS) {
-                break;
-              }
-
-              // Get the actual deduplicated account count from storage for the prompt
-              let currentAccountCount = accounts.length;
-              try {
-                const currentStorage = await loadAccounts();
-                if (currentStorage) {
-                  currentAccountCount = currentStorage.accounts.length;
-                }
-              } catch {
-                // Fall back to accounts.length if we can't read storage
-              }
-
-              const addAnother = await promptAddAnotherAccount(currentAccountCount);
-              if (!addAnother) {
-                break;
-              }
-            }
-
-            const primary = accounts[0];
-            if (!primary) {
-              return {
-                url: "",
-                instructions: "Authentication cancelled",
-                method: "auto",
-                callback: async () => ({ type: "failed", error: "Authentication cancelled" }),
+                },
               };
             }
 
-            // Get the actual deduplicated account count from storage
-            let actualAccountCount = accounts.length;
-            try {
-              const finalStorage = await loadAccounts();
-              if (finalStorage) {
-                actualAccountCount = finalStorage.accounts.length;
-              }
-            } catch {
-              // Fall back to accounts.length if we can't read storage
-            }
-
-            return {
-              url: "",
-              instructions: `Multi-account setup complete (${actualAccountCount} account(s)).`,
-              method: "auto",
-              callback: async (): Promise<AntigravityTokenExchangeResult> => primary,
-            };
-          }
-
-          // TUI flow (`/connect`) does not support per-account prompts.
-          // Default to adding new accounts (non-destructive).
-          // Users can run `opencode auth logout` first if they want a fresh start.
-          const projectId = "";
-
-          // Check existing accounts count for toast message
-          const existingStorage = await loadAccounts();
-          const existingCount = existingStorage?.accounts.length ?? 0;
-
-          const useManualFlow = isHeadless || shouldSkipLocalServer();
-
-          let listener: OAuthListener | null = null;
-          if (!useManualFlow) {
-            try {
-              listener = await startOAuthListener();
-            } catch {
-              listener = null;
-            }
-          }
-
-          const authorization = await authorizeAntigravity(projectId);
-          const fallbackState = getStateFromAuthorizationUrl(authorization.url);
-
-          if (!useManualFlow) {
-            const browserOpened = await openBrowser(authorization.url);
-            if (!browserOpened) {
-              listener?.close().catch(() => {});
-              listener = null;
-            }
-          }
-
-          if (listener) {
             return {
               url: authorization.url,
               instructions:
-                "Complete sign-in in your browser. We'll automatically detect the redirect back to localhost.",
-              method: "auto",
-              callback: async (): Promise<AntigravityTokenExchangeResult> => {
-                const CALLBACK_TIMEOUT_MS = 30000;
-                try {
-                  const callbackPromise = listener.waitForCallback();
-                  const timeoutPromise = new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error("CALLBACK_TIMEOUT")), CALLBACK_TIMEOUT_MS),
-                  );
+                "Visit the URL above, complete OAuth, then paste either the full redirect URL or the authorization code.",
+              method: "code",
+              callback: async (codeInput: string): Promise<AntigravityTokenExchangeResult> => {
+                const params = parseOAuthCallbackInput(codeInput, fallbackState);
+                if ("error" in params) {
+                  return { type: "failed", error: params.error };
+                }
 
-                  let callbackUrl: URL;
+                const result = await exchangeAntigravity(params.code, params.state);
+                if (result.type === "success") {
                   try {
-                    callbackUrl = await Promise.race([callbackPromise, timeoutPromise]);
-                  } catch (err) {
-                    if (err instanceof Error && err.message === "CALLBACK_TIMEOUT") {
-                      return {
-                        type: "failed",
-                        error: "Callback timeout - please use CLI with --no-browser flag for manual input",
-                      };
-                    }
-                    throw err;
-                  }
-
-                  const params = extractOAuthCallbackParams(callbackUrl);
-                  if (!params) {
-                    return { type: "failed", error: "Missing code or state in callback URL" };
-                  }
-
-                  const result = await exchangeAntigravity(params.code, params.state);
-                  if (result.type === "success") {
-                    try {
-                      await persistAccountPool([result], false);
-                    } catch {
-                    }
-
-                    const newTotal = existingCount + 1;
-                    const toastMessage = existingCount > 0
-                      ? `Added account${result.email ? ` (${result.email})` : ""} - ${newTotal} total`
-                      : `Authenticated${result.email ? ` (${result.email})` : ""}`;
-
-                    try {
-                      await client.tui.showToast({
-                        body: {
-                          message: toastMessage,
-                          variant: "success",
-                        },
-                      });
-                    } catch {
-                    }
-                  }
-
-                  return result;
-                } catch (error) {
-                  return {
-                    type: "failed",
-                    error: error instanceof Error ? error.message : "Unknown error",
-                  };
-                } finally {
-                  try {
-                    await listener.close();
+                    // TUI flow adds to existing accounts (non-destructive)
+                    await persistAccountPool([result], false);
                   } catch {
+                    // ignore
+                  }
+
+                  // Show appropriate toast message
+                  const newTotal = existingCount + 1;
+                  const toastMessage = existingCount > 0
+                    ? `Added account${result.email ? ` (${result.email})` : ""} - ${newTotal} total`
+                    : `Authenticated${result.email ? ` (${result.email})` : ""}`;
+
+                  try {
+                    await client.tui.showToast({
+                      body: {
+                        message: toastMessage,
+                        variant: "success",
+                      },
+                    });
+                  } catch {
+                    // TUI may not be available
                   }
                 }
+
+                return result;
               },
             };
-          }
-
-          return {
-            url: authorization.url,
-            instructions:
-              "Visit the URL above, complete OAuth, then paste either the full redirect URL or the authorization code.",
-            method: "code",
-            callback: async (codeInput: string): Promise<AntigravityTokenExchangeResult> => {
-              const params = parseOAuthCallbackInput(codeInput, fallbackState);
-              if ("error" in params) {
-                return { type: "failed", error: params.error };
-              }
-
-              const result = await exchangeAntigravity(params.code, params.state);
-              if (result.type === "success") {
-                try {
-                  // TUI flow adds to existing accounts (non-destructive)
-                  await persistAccountPool([result], false);
-                } catch {
-                  // ignore
-                }
-
-                // Show appropriate toast message
-                const newTotal = existingCount + 1;
-                const toastMessage = existingCount > 0
-                  ? `Added account${result.email ? ` (${result.email})` : ""} - ${newTotal} total`
-                  : `Authenticated${result.email ? ` (${result.email})` : ""}`;
-
-                try {
-                  await client.tui.showToast({
-                    body: {
-                      message: toastMessage,
-                      variant: "success",
-                    },
-                  });
-                } catch {
-                  // TUI may not be available
-                }
-              }
-
-              return result;
-            },
-          };
+          },
         },
-      },
-      {
-        label: "Manually enter API Key",
-        type: "api",
-      },
-    ],
-  },
+        {
+          label: "Manually enter API Key",
+          type: "api",
+        },
+      ],
+    },
   };
 };
 

--- a/src/plugin/request-helpers.ts
+++ b/src/plugin/request-helpers.ts
@@ -495,9 +495,9 @@ function flattenTypeArrays(schema: any, nullableFields?: Map<string, string[]>, 
       newProps[propKey] = processed;
 
       // Track nullable fields for required array cleanup
-      if (processed && typeof processed === "object" && 
-          typeof processed.description === "string" && 
-          processed.description.includes("nullable")) {
+      if (processed && typeof processed === "object" &&
+        typeof processed.description === "string" &&
+        processed.description.includes("nullable")) {
         const objectPath = currentPath || "";
         const existing = localNullableFields.get(objectPath) || [];
         existing.push(propKey);
@@ -581,7 +581,7 @@ function cleanupRequiredFields(schema: any): any {
 
   // Clean up required array if properties exist
   if (Array.isArray(result.required) && result.properties && typeof result.properties === "object") {
-    const validRequired = result.required.filter((req: string) => 
+    const validRequired = result.required.filter((req: string) =>
       Object.prototype.hasOwnProperty.call(result.properties, req)
     );
     if (validRequired.length === 0) {
@@ -1132,9 +1132,9 @@ export function filterUnsignedThinkingBlocks(
 
     if (Array.isArray((content as any).content)) {
       const isAssistantRole = (content as any).role === "assistant";
-      const isLastAssistantContent = idx === lastAssistantIdx || 
+      const isLastAssistantContent = idx === lastAssistantIdx ||
         (isAssistantRole && idx === findLastAssistantIndex(contents, "assistant"));
-      
+
       const filteredContent = filterContentArray(
         (content as any).content,
         sessionId,
@@ -1173,7 +1173,7 @@ export function filterMessagesThinkingBlocks(
     if (Array.isArray((message as any).content)) {
       const isAssistantRole = (message as any).role === "assistant";
       const isLastAssistant = isAssistantRole && idx === lastAssistantIdx;
-      
+
       const filteredContent = filterContentArray(
         (message as any).content,
         sessionId,
@@ -1542,30 +1542,30 @@ export function isEmptyResponseBody(text: string): boolean {
 
   try {
     const parsed = JSON.parse(text);
-    
+
     // Check for empty candidates (Gemini/Antigravity format)
     if (parsed.candidates !== undefined) {
       if (!Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
         return true;
       }
-      
+
       // Check if first candidate has empty content
       const firstCandidate = parsed.candidates[0];
       if (!firstCandidate) {
         return true;
       }
-      
+
       // Check for empty parts in content
       const content = firstCandidate.content;
       if (!content || typeof content !== "object") {
         return true;
       }
-      
+
       const parts = content.parts;
       if (!Array.isArray(parts) || parts.length === 0) {
         return true;
       }
-      
+
       // Check if all parts are empty (no text, no functionCall)
       const hasContent = parts.some((part: any) => {
         if (!part || typeof part !== "object") return false;
@@ -1574,35 +1574,35 @@ export function isEmptyResponseBody(text: string): boolean {
         if (part.thought === true && typeof part.text === "string") return true;
         return false;
       });
-      
+
       if (!hasContent) {
         return true;
       }
     }
-    
+
     // Check for empty choices (OpenAI format - shouldn't occur but handle it)
     if (parsed.choices !== undefined) {
       if (!Array.isArray(parsed.choices) || parsed.choices.length === 0) {
         return true;
       }
-      
+
       const firstChoice = parsed.choices[0];
       if (!firstChoice) {
         return true;
       }
-      
+
       // Check for empty message/delta
       const message = firstChoice.message || firstChoice.delta;
       if (!message) {
         return true;
       }
-      
+
       // Check if message has content or tool_calls
       if (!message.content && !message.tool_calls && !message.reasoning_content) {
         return true;
       }
     }
-    
+
     // Check response wrapper (Antigravity envelope)
     if (parsed.response !== undefined) {
       const response = parsed.response;
@@ -1611,7 +1611,7 @@ export function isEmptyResponseBody(text: string): boolean {
       }
       return isEmptyResponseBody(JSON.stringify(response));
     }
-    
+
     return false;
   } catch {
     // JSON parse error - treat as empty
@@ -1655,7 +1655,7 @@ export function isMeaningfulSseLine(line: string): boolean {
   }
 
   const data = line.slice(6).trim();
-  
+
   if (data === "[DONE]") {
     return false;
   }
@@ -1666,7 +1666,7 @@ export function isMeaningfulSseLine(line: string): boolean {
 
   try {
     const parsed = JSON.parse(data);
-    
+
     // Check for candidates with content
     if (parsed.candidates && Array.isArray(parsed.candidates)) {
       for (const candidate of parsed.candidates) {
@@ -1679,12 +1679,12 @@ export function isMeaningfulSseLine(line: string): boolean {
         }
       }
     }
-    
+
     // Check response wrapper
     if (parsed.response?.candidates) {
       return isMeaningfulSseLine(`data: ${JSON.stringify(parsed.response)}`);
     }
-    
+
     return false;
   } catch {
     return false;
@@ -1827,24 +1827,24 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
   }
 
   const newContents: any[] = [];
-  
+
   // Track pending tool call groups that need responses
   const pendingGroups: Array<{
     ids: string[];
     funcNames: string[];
     insertAfterIdx: number;
   }> = [];
-  
+
   // Collected orphan responses (by ID)
   const collectedResponses = new Map<string, any>();
-  
+
   for (const content of contents) {
     const role = content.role;
     const parts = content.parts || [];
-    
+
     // Check if this is a tool response message
     const responseParts = parts.filter((p: any) => p?.functionResponse);
-    
+
     if (responseParts.length > 0) {
       // Collect responses by ID (skip duplicates)
       for (const resp of responseParts) {
@@ -1853,7 +1853,7 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
           collectedResponses.set(respId, resp);
         }
       }
-      
+
       // Try to satisfy the most recent pending group
       for (let i = pendingGroups.length - 1; i >= 0; i--) {
         const group = pendingGroups[i]!;
@@ -1871,19 +1871,19 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
       }
       continue; // Don't add the original response message
     }
-    
+
     if (role === "model") {
       // Check for function calls in this model message
       const funcCalls = parts.filter((p: any) => p?.functionCall);
       newContents.push(content);
-      
+
       if (funcCalls.length > 0) {
         const callIds = funcCalls
           .map((fc: any) => fc.functionCall?.id || "")
           .filter(Boolean);
         const funcNames = funcCalls
           .map((fc: any) => fc.functionCall?.name || "");
-        
+
         if (callIds.length > 0) {
           pendingGroups.push({
             ids: callIds,
@@ -1896,18 +1896,18 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
       newContents.push(content);
     }
   }
-  
+
   // Handle remaining pending groups with orphan recovery
   // Process in reverse order so insertions don't shift indices
   pendingGroups.sort((a, b) => b.insertAfterIdx - a.insertAfterIdx);
-  
+
   for (const group of pendingGroups) {
     const groupResponses: any[] = [];
-    
+
     for (let i = 0; i < group.ids.length; i++) {
       const expectedId = group.ids[i]!;
       const expectedName = group.funcNames[i] || "";
-      
+
       if (collectedResponses.has(expectedId)) {
         // Direct ID match - ideal case
         groupResponses.push(collectedResponses.get(expectedId));
@@ -1915,7 +1915,7 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
       } else if (collectedResponses.size > 0) {
         // Need to find an orphan response
         let matchedId: string | null = null;
-        
+
         // Pass 1: Match by function name
         for (const [orphanId, orphanResp] of collectedResponses) {
           const orphanName = orphanResp.functionResponse?.name || "";
@@ -1924,7 +1924,7 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
             break;
           }
         }
-        
+
         // Pass 2: Match "unknown_function" orphans
         if (!matchedId) {
           for (const [orphanId, orphanResp] of collectedResponses) {
@@ -1934,28 +1934,28 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
             }
           }
         }
-        
+
         // Pass 3: Take first available
         if (!matchedId) {
           matchedId = collectedResponses.keys().next().value ?? null;
         }
-        
+
         if (matchedId) {
           const orphanResp = collectedResponses.get(matchedId)!;
           collectedResponses.delete(matchedId);
-          
+
           // Fix the ID and name to match expected
           orphanResp.functionResponse.id = expectedId;
           if (orphanResp.functionResponse.name === "unknown_function" && expectedName) {
             orphanResp.functionResponse.name = expectedName;
           }
-          
+
           log.debug("Auto-repaired tool ID mismatch", {
             mappedFrom: matchedId,
             mappedTo: expectedId,
             functionName: expectedName,
           });
-          
+
           groupResponses.push(orphanResp);
         }
       } else {
@@ -1966,23 +1966,23 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
             response: {
               result: {
                 error: "Tool response was lost during context processing. " +
-                       "This is a recovered placeholder.",
+                  "This is a recovered placeholder.",
                 recovered: true,
               },
             },
             id: expectedId,
           },
         };
-        
+
         log.debug("Created placeholder response for missing tool", {
           id: expectedId,
           name: expectedName,
         });
-        
+
         groupResponses.push(placeholder);
       }
     }
-    
+
     if (groupResponses.length > 0) {
       // Insert at correct position (after the model message that made the calls)
       newContents.splice(group.insertAfterIdx + 1, 0, {
@@ -1991,7 +1991,7 @@ export function fixToolResponseGrouping(contents: any[]): any[] {
       });
     }
   }
-  
+
   return newContents;
 }
 
@@ -2010,10 +2010,10 @@ export function detectToolIdMismatches(contents: any[]): {
 } {
   const expectedIds: string[] = [];
   const foundIds: string[] = [];
-  
+
   for (const content of contents) {
     const parts = content.parts || [];
-    
+
     for (const part of parts) {
       if (part?.functionCall?.id) {
         expectedIds.push(part.functionCall.id);
@@ -2023,13 +2023,13 @@ export function detectToolIdMismatches(contents: any[]): {
       }
     }
   }
-  
+
   const expectedSet = new Set(expectedIds);
   const foundSet = new Set(foundIds);
-  
+
   const missingIds = expectedIds.filter(id => !foundSet.has(id));
   const orphanIds = foundIds.filter(id => !expectedSet.has(id));
-  
+
   return {
     hasMismatches: missingIds.length > 0 || orphanIds.length > 0,
     expectedIds,
@@ -2327,7 +2327,7 @@ export function injectParameterSignatures(
       });
 
       const sigStr = promptTemplate.replace("{params}", paramList.join(", "));
-      
+
       return {
         ...decl,
         description: (decl.description || "") + sigStr,
@@ -2554,10 +2554,10 @@ export function createSyntheticErrorResponse(
 ): Response {
   // Generate a unique message ID
   const messageId = `msg_synthetic_${Date.now()}`;
-  
+
   // Build Claude SSE events that represent a complete message with error text
   const events: string[] = [];
-  
+
   // 1. message_start event
   events.push(`event: message_start
 data: ${JSON.stringify({
@@ -2633,5 +2633,32 @@ data: ${JSON.stringify({ type: "message_stop" })}
       "X-Antigravity-Error-Type": "prompt_too_long",
     },
   });
+}
+
+// Fresh account provisioning error detection
+// When new google accounts try to use antigravity they sometimes get denied
+// because google hasnt set them up yet. this helps catch that case
+
+const CLOUD_AI_COMPANION_PERMISSION = "cloudaicompanion.companions.generateChat";
+
+/**
+ * Checks if this is one of those annoying "permission denied" errors that 
+ * happens when someone's google account is brand new and hasnt been provisioned yet
+ */
+export function isCloudAICompanionPermissionDenied(bodyText: string): boolean {
+  if (!bodyText || typeof bodyText !== "string") {
+    return false;
+  }
+  return bodyText.includes(CLOUD_AI_COMPANION_PERMISSION) &&
+    bodyText.toLowerCase().includes("denied");
+}
+
+/**
+ * Friendly error message so users know whats going on and dont panic
+ */
+export function getProvisioningErrorMessage(): string {
+  return "Account not yet provisioned for Antigravity. " +
+    "This typically resolves within 5-15 minutes for fresh accounts. " +
+    "Try using gemini-2.5-flash first, then retry Claude models.";
 }
 


### PR DESCRIPTION
Fresh google accounts sometimes get 403 errors because they havent been provisioned for antigravity yet. This adds detection for that specific error and shows a friendly message telling users to wait a bit or try gemini models first.

- Added isCloudAICompanionPermissionDenied() helper to detect the error

- Added getProvisioningErrorMessage() for the user-friendly message

- Shows toast when this error is detected

- Added tests for the new helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed two new public helper functions for Cloud AI Companion error detection and user-friendly error messaging.

* **Tests**
  * Added comprehensive unit tests for the new helpers, validating error detection logic and message content across multiple scenarios and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->