### PR TITLE
feat: progressive rate limit retry with switch_on_first_rate_limit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Create `~/.config/opencode/antigravity.json` (or `.opencode/antigravity.json` in
 | `proactive_refresh_buffer_seconds` | `1800` | Refresh 30min before expiry |
 | `max_rate_limit_wait_seconds` | `300` | Max wait time when rate limited (0=unlimited) |
 | `quota_fallback` | `false` | Try alternate quota when rate limited |
+| `switch_on_first_rate_limit` | `true` | Switch account immediately on first 429 (after 1s) |
 
 ### Account Selection
 

--- a/src/plugin/config/schema.ts
+++ b/src/plugin/config/schema.ts
@@ -253,9 +253,17 @@ export const AntigravityConfigSchema = z.object({
    * @default false
    */
   pid_offset_enabled: z.boolean().default(false),
-  
-  // =========================================================================
-  // Auto-Update
+   
+   /**
+    * Switch to another account immediately on first rate limit (after 1s delay).
+    * When disabled, retries same account first, then switches on second rate limit.
+    * 
+    * @default true
+    */
+   switch_on_first_rate_limit: z.boolean().default(true),
+   
+   // =========================================================================
+   // Auto-Update
   // =========================================================================
   
   /**
@@ -288,8 +296,9 @@ export const DEFAULT_CONFIG: AntigravityConfig = {
   max_rate_limit_wait_seconds: 300,
   quota_fallback: false,
   account_selection_strategy: 'sticky',
-  pid_offset_enabled: false,
-  auto_update: true,
+pid_offset_enabled: false,
+   switch_on_first_rate_limit: true,
+   auto_update: true,
   signature_cache: {
     enabled: true,
     memory_ttl_seconds: 3600,


### PR DESCRIPTION
## Summary

- Implements progressive rate limit retry to reduce latency when hitting 429 errors
- Adds `switch_on_first_rate_limit` config option (default: `true`)

## Behavior

| Config | First 429 | Second 429 |
|--------|-----------|------------|
| `switch_on_first_rate_limit: true` | Wait 1s → switch account | N/A |
| `switch_on_first_rate_limit: false` | Wait 1s → retry same | Wait 5s → switch |
| **Single account** | Wait 1s → retry | Exponential backoff (2s, 4s, 8s... max 60s) |

## Changes

- `src/plugin.ts`: Replace `SHORT_RETRY_THRESHOLD_MS` with progressive retry logic using `FIRST_RETRY_DELAY_MS` (1s) and `SWITCH_ACCOUNT_DELAY_MS` (5s)
- `src/plugin/config/schema.ts`: Add `switch_on_first_rate_limit` config option with JSDoc
- `README.md`: Document new config option

## Testing

- All 558 existing tests pass

Fixes #147