### PR TITLE
docs: Add Safari/browser OAuth troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,8 @@ Try add this line to in `google` field under `provider`
 ### Error during the session
 If you encounter error during the session, try chat `continue` the recover session mechanism should be trigger and you can continue the session, if the error blocked the session please workaround by use command `/undo` to revert to the state before the error and try again it should work
 
-### Safari OAuth Callback Fails (macOS)
+<details>
+<summary><b>Safari OAuth Callback Fails (macOS)</b></summary>
 
 **Symptoms:**
 - "fail to authorize" after successful Google login in browser
@@ -569,7 +570,10 @@ If you encounter error during the session, try chat `continue` the recover sessi
    - The URL should contain `?code=...&scope=...`
    - This auth code can be used manually (see [issue #119](https://github.com/NoeFabris/opencode-antigravity-auth/issues/119) for updates on manual auth support)
 
-### Port Already in Use
+</details>
+
+<details>
+<summary><b>Port Already in Use</b></summary>
 
 If OAuth fails with "Address already in use" or similar port binding errors:
 
@@ -598,13 +602,18 @@ taskkill /PID <PID> /F
 opencode auth login
 ```
 
-### WSL2 / Remote Development
+</details>
+
+<details>
+<summary><b>WSL2 / Remote Development</b></summary>
 
 For users running OpenCode in WSL2 or over SSH:
 - The OAuth callback requires the browser to reach `localhost` on the machine running OpenCode
 - For WSL2: Ensure port forwarding is configured, or use VS Code's port forwarding
 - For SSH: Use SSH port forwarding: `ssh -L 8080:localhost:8080 user@remote`
 - For headless servers: See [issue #119](https://github.com/NoeFabris/opencode-antigravity-auth/issues/119) for manual URL auth (in development)
+
+</details>
 
 ## Known Plugin Interactions
 


### PR DESCRIPTION
## Summary

Adds documentation for browser-specific OAuth callback issues that users encounter during `opencode auth login`:

- **Safari HTTPS-Only Mode** - Documents that Safari's default HTTPS-Only Mode blocks `http://localhost` callbacks, causing "fail to authorize" errors
- **Port conflict resolution** - Steps to identify and kill processes blocking the OAuth callback port
- **WSL2/SSH guidance** - Port forwarding instructions for remote development scenarios
- References [issue #119](https://github.com/NoeFabris/opencode-antigravity-auth/issues/119) for manual auth feature

## Problem

Users on macOS with Safari as their default browser experience silent OAuth failures. The callback to `http://localhost:PORT` is blocked by Safari's HTTPS-Only Mode, resulting in confusing "fail to authorize" errors with no clear resolution path.

This is not currently documented in the troubleshooting section.

## Changes

- Added new troubleshooting subsections after "Error during the session":
  - `Safari OAuth Callback Fails (macOS)`
  - `Port Already in Use`
  - `WSL2 / Remote Development`

## Testing

- Verified the Safari HTTPS-Only Mode issue on macOS Sequoia
- Confirmed the workarounds (using Chrome, disabling HTTPS-Only Mode) resolve the issue

## Compliance

- [x] This contribution is for documentation only
- [x] No code changes, only README.md updates
- [x] References existing issue (#119) appropriately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guides: "Safari OAuth Callback Fails (macOS)" with symptoms and three remediation options; "Port Already in Use" with cross‑platform commands to identify/stop conflicting processes; and "WSL2 / Remote Development" guidance for running and accessing the app (including port‑forwarding and SSH notes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->