### PR TITLE
fix: remove additionalProperties from Gemini tool schemas and apply cleanJSONSchemaForAntigravity

### DIFF
--- a/src/plugin/transform/gemini.ts
+++ b/src/plugin/transform/gemini.ts
@@ -96,7 +96,6 @@ export function normalizeGeminiTools(
         },
       },
       required: ["_placeholder"],
-      additionalProperties: false,
     };
 
     let schema = schemaCandidates[0] as Record<string, unknown> | undefined;
@@ -145,12 +144,10 @@ export function normalizeGeminiTools(
       }
     }
     
-    // Ensure custom has input_schema
     if (newTool.custom && !(newTool.custom as Record<string, unknown>).input_schema) {
       (newTool.custom as Record<string, unknown>).input_schema = { 
         type: "object", 
         properties: {}, 
-        additionalProperties: false 
       };
       toolDebugMissing += 1;
     }


### PR DESCRIPTION
## Summary
- Removes `additionalProperties: false` from placeholder schemas in `request.ts` and `gemini.ts`
- Applies `cleanJSONSchemaForAntigravity()` to all Gemini tool parameters, which strips unsupported fields and handles `required` array cleanup

## Problem
The Gemini API rejects the `additionalProperties` field in tool schemas with 400 errors:
- Issue #163: Built-in tools (todoread, etc.) have invalid schemas for Gemini API
- Issue #161: Error when using Gemini 3 Pro/Flash with MCP servers enabled (`required[2]: property is not defined`)

## Root Cause
1. Placeholder schemas for tools without schemas included `additionalProperties: false` which Gemini rejects
2. Gemini tool schemas were not being cleaned through `cleanJSONSchemaForAntigravity()` which handles:
   - Stripping `additionalProperties`
   - Cleaning up `required` arrays to only reference existing properties
   - Removing other unsupported JSON Schema fields

## Testing
- All 558 unit tests pass
- Build passes
- TypeScript type check passes

Fixes #163, #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation and deterministic fallback handling for tool parameter schemas in Gemini integrations, ensuring more robust processing of tools with missing or incomplete parameter definitions.
  * Enhanced schema flexibility by allowing additional properties in fallback tool parameter definitions, improving compatibility and reliability with various tool configurations and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->