### PR TITLE
fix(oauth): bind callback server to localhost for Ubuntu compatibility

### DIFF
--- a/src/plugin/server.ts
+++ b/src/plugin/server.ts
@@ -33,8 +33,8 @@ export async function startOAuthListener(
   const port = redirectUri.port
     ? Number.parseInt(redirectUri.port, 10)
     : redirectUri.protocol === "https:"
-    ? 443
-    : 80;
+      ? 443
+      : 80;
   const origin = `${redirectUri.protocol}//${redirectUri.host}`;
 
   let settled = false;
@@ -56,7 +56,7 @@ export async function startOAuthListener(
     };
   });
 
-const successResponse = `<!DOCTYPE html>
+  const successResponse = `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -225,7 +225,7 @@ const successResponse = `<!DOCTYPE html>
       reject(error);
     };
     server.once("error", handleError);
-    server.listen(port, () => {
+    server.listen(port, "localhost", () => {
       server.off("error", handleError);
       resolve();
     });


### PR DESCRIPTION
## Problem

OAuth authentication fails on Ubuntu/Linux systems. After completing Google sign-in in the browser, the callback cannot reach the local server, resulting in the browser showing "waiting for localhost..." indefinitely.

Windows users are **not** affected.

## Root Cause

In [src/plugin/server.ts](cci:7://file:///home/novis/investigate/opencode-antigravity-auth/src/plugin/server.ts:0:0-0:0), `server.listen(port)` doesn't specify a hostname. On Ubuntu with IPv6 enabled:
- Node.js binds to [::](cci:7://file:///home/novis/investigate/opencode-antigravity-auth:0:0-0:0) (IPv6 all addresses)
- OAuth redirect URI uses `http://localhost:51121`
- Browser resolves `localhost` to IPv4 `127.0.0.1`
- Connection fails due to address family mismatch

**Diagnostic evidence** (tested on Ubuntu 22.04):
Without hostname: Server listening on {"address":"::","family":"IPv6","port":51121} With "localhost": Server listening on {"address":"127.0.0.1","family":"IPv4","port":51121}


## Solution

Explicitly specify `'localhost'` as the hostname parameter:

```typescript
server.listen(port, 'localhost', () => {
  // ...
});

This ensures the server binds to IPv4 127.0.0.1, matching the redirect URI.

Testing
✅ First account authentication now succeeds on Ubuntu
✅ Build passes
✅ No impact on Windows/macOS (already working)
Note
Multi-account sequential authentication may have a separate timing issue with port release between accounts. This PR focuses on the primary IPv6 binding fix.