### PR TITLE
feat: add direct refresh token input for adding accounts

### DIFF
--- a/src/plugin/cli.ts
+++ b/src/plugin/cli.ts
@@ -66,3 +66,50 @@ export async function promptLoginMode(existingAccounts: ExistingAccountInfo[]): 
     rl.close();
   }
 }
+
+export type AuthMethod = "oauth" | "refresh_token";
+
+/**
+ * Prompts user to choose authentication method.
+ * Returns "oauth" for standard OAuth flow, "refresh_token" for direct token input.
+ */
+export async function promptAuthMethod(): Promise<AuthMethod> {
+  const rl = createInterface({ input, output });
+  try {
+    console.log("\nAuthentication method:");
+    console.log("  1. OAuth with Google (browser login)");
+    console.log("  2. Direct refresh token input");
+    console.log("");
+
+    while (true) {
+      const answer = await rl.question("Choose method [1/2]: ");
+      const normalized = answer.trim();
+
+      if (normalized === "1" || normalized === "oauth") {
+        return "oauth";
+      }
+      if (normalized === "2" || normalized === "refresh_token" || normalized === "token") {
+        return "refresh_token";
+      }
+
+      console.log("Please enter '1' for OAuth or '2' for refresh token.");
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Prompts user for a Google refresh token.
+ */
+export async function promptRefreshToken(): Promise<string> {
+  const rl = createInterface({ input, output });
+  try {
+    console.log("\nEnter your Google refresh token.");
+    console.log("(The token should be obtained from a previous OAuth flow)\n");
+    const answer = await rl.question("Refresh token: ");
+    return answer.trim();
+  } finally {
+    rl.close();
+  }
+}


### PR DESCRIPTION
## Summary
  - Add "Direct Refresh Token Input" option in login methods
  - Users can now add accounts by directly pasting a Google refresh token
  - Supports both CLI and TUI flows

  ## Use Cases
  - Headless/SSH environments where browser auth is difficult
  - Sharing tokens across machines
  - Quickly adding accounts from existing token storage

  ## Changes
  - `src/plugin/cli.ts`: Add `promptAuthMethod()` and `promptRefreshToken()` functions
  - `src/antigravity/oauth.ts`: Add `validateRefreshToken()` function
  - `src/plugin.ts`: Integrate refresh token authentication option