### PR TITLE
fix: route gemini-3-*-preview models to Antigravity quota

### DIFF
--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -80,24 +80,25 @@ const ANTIGRAVITY_ONLY_MODELS = /^(claude|gpt)/i;
 const IMAGE_GENERATION_MODELS = /image|imagen/i;
 
 /**
- * Legacy Gemini 3 model names that should route to Antigravity quota.
+ * Gemini 3 model names that should route to Antigravity quota.
  *
- * Backward compatibility: Since Gemini CLI now uses -preview suffix
- * (gemini-3-pro-preview, gemini-3-flash-preview), old model names
- * without -preview can safely route to Antigravity quota.
+ * Routes ALL Gemini 3 variants (including -preview) to Antigravity quota
+ * for consistent quota consumption across the entire Gemini 3 family.
  *
  * Matches:
- * - gemini-3-pro-low, gemini-3-pro-high
+ * - gemini-3-pro, gemini-3-pro-low, gemini-3-pro-high
+ * - gemini-3-pro-preview, gemini-3-pro-preview-low, gemini-3-pro-preview-high
  * - gemini-3-flash, gemini-3-flash-low, gemini-3-flash-medium, gemini-3-flash-high
+ * - gemini-3-flash-preview, gemini-3-flash-preview-low, etc.
  *
  * Does NOT match:
- * - gemini-3-pro-preview (Gemini CLI)
- * - gemini-3-flash-preview (Gemini CLI)
  * - antigravity-gemini-3-* (already handled by prefix)
  *
- * WARNING: This may break if Google/Opencode removes the -preview suffix.
+ * Rationale: OpenCode's title agent uses gemini-3-flash-preview internally.
+ * Without this fix, title agent calls would consume Gemini CLI quota instead
+ * of Antigravity quota, causing unexpected quota exhaustion.
  */
-const LEGACY_ANTIGRAVITY_GEMINI3 = /^gemini-3-(pro-(low|high)|flash(-low|-medium|-high)?)$/i;
+const LEGACY_ANTIGRAVITY_GEMINI3 = /^gemini-3-(pro|flash)(-preview)?(-low|-medium|-high)?$/i;
 
 /**
  * Models that support thinking tier suffixes.


### PR DESCRIPTION
## Summary

- **Bug**: `LEGACY_ANTIGRAVITY_GEMINI3` regex was missing `-preview` suffix variants
- **Impact**: `gemini-3-flash-preview` and `gemini-3-pro-preview` incorrectly routed to Gemini CLI quota instead of Antigravity quota
- **Root cause**: OpenCode's title agent uses `gemini-3-flash-preview` internally, causing unexpected quota consumption

## Problem Details

The original regex:
```typescript
/^gemini-3-(pro-(low|high)|flash(-low|-medium|-high)?)$/i
```

**Did NOT match:**
| Model | Matched? | Quota Used |
|-------|----------|------------|
| `gemini-3-flash` | ✅ | Antigravity |
| `gemini-3-flash-low` | ✅ | Antigravity |
| `gemini-3-flash-preview` | ❌ | **Gemini CLI** ← Bug |
| `gemini-3-pro-preview` | ❌ | **Gemini CLI** ← Bug |

## Fix

Updated regex to include optional `-preview` suffix:
```typescript
/^gemini-3-(pro|flash)(-preview)?(-low|-medium|-high)?$/i
```

**Now matches all Gemini 3 variants consistently:**
- `gemini-3-pro`, `gemini-3-pro-low`, `gemini-3-pro-high`
- `gemini-3-pro-preview`, `gemini-3-pro-preview-low`, `gemini-3-pro-preview-high`
- `gemini-3-flash`, `gemini-3-flash-low`, `gemini-3-flash-medium`, `gemini-3-flash-high`
- `gemini-3-flash-preview`, `gemini-3-flash-preview-low`, etc.

## Testing

Verified regex matches expected models:
```javascript
const regex = /^gemini-3-(pro|flash)(-preview)?(-low|-medium|-high)?$/i;
console.log(regex.test('gemini-3-flash-preview')); // true
console.log(regex.test('gemini-3-pro-preview')); // true
console.log(regex.test('gemini-3-flash')); // true
console.log(regex.test('gemini-3-pro-low')); // true
```