### PR TITLE
fix(model-resolver): prevent tier suffix on image generation models

### DIFF
--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -340,8 +340,10 @@ export function resolveModelForHeaderStyle(
     
     const isGemini3Pro = transformedModel.toLowerCase().startsWith("gemini-3-pro");
     const hasTierSuffix = /-(low|medium|high)$/i.test(transformedModel);
+    const isImageModel = IMAGE_GENERATION_MODELS.test(transformedModel);
     
-    if (isGemini3Pro && !hasTierSuffix) {
+    // Don't add tier suffix to image models - they don't support thinking
+    if (isGemini3Pro && !hasTierSuffix && !isImageModel) {
       transformedModel = `${transformedModel}-low`;
     }
     


### PR DESCRIPTION
## Problem

Image generation models like `gemini-3-pro-image` were incorrectly getting `-low` appended, causing API requests to fail.

**Expected:** `gemini-3-pro-image`  
**Actual:** `gemini-3-pro-image-low`

This happens because the model name starts with `gemini-3-pro`, triggering the auto-append logic for thinking tiers:

```typescript
const isGemini3Pro = transformedModel.toLowerCase().startsWith("gemini-3-pro");
//    "gemini-3-pro-image".startsWith("gemini-3-pro") → true ❌
```

## Root Cause

`resolveModelForHeaderStyle()` was missing the `isImageModel` check that already exists in `resolveModelWithTier()`.

## Fix

```diff
  const isGemini3Pro = transformedModel.toLowerCase().startsWith("gemini-3-pro");
  const hasTierSuffix = /-(low|medium|high)$/i.test(transformedModel);
+ const isImageModel = IMAGE_GENERATION_MODELS.test(transformedModel);

- if (isGemini3Pro && !hasTierSuffix) {
+ if (isGemini3Pro && !hasTierSuffix && !isImageModel) {
    transformedModel = `${transformedModel}-low`;
  }
```

## Testing

- [x] Unit tests pass (`npm test -- --testNamePattern="image|resolveModel"` - 30 passed)
- [x] Manual: `opencode run "red circle" --model=google/antigravity-gemini-3-pro-image` successfully generated image

## Related

Affects the image generation feature added in v1.3.0.