### PR TITLE
fix: prevent tool schema loss for custom-only tools and empty properties

### DIFF
--- a/src/plugin/transform/gemini.ts
+++ b/src/plugin/transform/gemini.ts
@@ -1,26 +1,31 @@
 /**
  * Gemini-specific Request Transformations
- * 
+ *
  * Handles Gemini model-specific request transformations including:
  * - Thinking config (camelCase keys, thinkingLevel for Gemini 3)
  * - Tool normalization (function/custom format)
  * - Schema transformation (JSON Schema -> Gemini Schema format)
  */
 
-import type { RequestPayload, ThinkingConfig, ThinkingTier, GoogleSearchConfig } from "./types";
+import type {
+  RequestPayload,
+  ThinkingConfig,
+  ThinkingTier,
+  GoogleSearchConfig,
+} from "./types";
 
 /**
  * Transform a JSON Schema to Gemini-compatible format.
  * Based on @google/genai SDK's processJsonSchema() function.
- * 
+ *
  * Key transformations:
  * - Converts type values to uppercase (object -> OBJECT)
  * - Removes unsupported fields like additionalProperties, $schema
  * - Recursively processes nested schemas (properties, items, anyOf, etc.)
- * 
+ *
  * @param schema - A JSON Schema object or primitive value
  * @returns Gemini-compatible schema
- * 
+ *
  * Fields that Gemini API rejects and must be removed from schemas.
  * Antigravity uses strict protobuf-backed JSON validation.
  */
@@ -61,7 +66,9 @@ export function toGeminiSchema(schema: unknown): unknown {
   // First pass: collect all property names for required validation
   const propertyNames = new Set<string>();
   if (inputSchema.properties && typeof inputSchema.properties === "object") {
-    for (const propName of Object.keys(inputSchema.properties as Record<string, unknown>)) {
+    for (const propName of Object.keys(
+      inputSchema.properties as Record<string, unknown>,
+    )) {
       propertyNames.add(propName);
     }
   }
@@ -75,17 +82,26 @@ export function toGeminiSchema(schema: unknown): unknown {
     if (key === "type" && typeof value === "string") {
       // Convert type to uppercase for Gemini API
       result[key] = value.toUpperCase();
-    } else if (key === "properties" && typeof value === "object" && value !== null) {
+    } else if (
+      key === "properties" &&
+      typeof value === "object" &&
+      value !== null
+    ) {
       // Recursively transform nested property schemas
       const props: Record<string, unknown> = {};
-      for (const [propName, propSchema] of Object.entries(value as Record<string, unknown>)) {
+      for (const [propName, propSchema] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
         props[propName] = toGeminiSchema(propSchema);
       }
       result[key] = props;
     } else if (key === "items" && typeof value === "object") {
       // Transform array items schema
       result[key] = toGeminiSchema(value);
-    } else if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+    } else if (
+      (key === "anyOf" || key === "oneOf" || key === "allOf") &&
+      Array.isArray(value)
+    ) {
       // Transform union type schemas
       result[key] = value.map((item) => toGeminiSchema(item));
     } else if (key === "enum" && Array.isArray(value)) {
@@ -98,8 +114,8 @@ export function toGeminiSchema(schema: unknown): unknown {
       // Filter required array to only include properties that exist
       // This fixes: "parameters.required[X]: property is not defined"
       if (propertyNames.size > 0) {
-        const validRequired = value.filter((prop) =>
-          typeof prop === "string" && propertyNames.has(prop)
+        const validRequired = value.filter(
+          (prop) => typeof prop === "string" && propertyNames.has(prop),
         );
         if (validRequired.length > 0) {
           result[key] = validRequired;
@@ -118,6 +134,32 @@ export function toGeminiSchema(schema: unknown): unknown {
   // Gemini API requires: "parameters.properties[X].items: missing field"
   if (result.type === "ARRAY" && !result.items) {
     result.items = { type: "STRING" };
+  }
+
+  // Fix: Ensure OBJECT schemas have at least one property
+  // Gemini API rejects empty properties: {} with 400 Bad Request
+  // Note: Preserves existing required array for malformed inputs where
+  // properties are empty but required is set (defensive handling)
+  if (
+    result.type === "OBJECT" &&
+    result.properties &&
+    typeof result.properties === "object" &&
+    Object.keys(result.properties as Record<string, unknown>).length === 0
+  ) {
+    result.properties = {
+      _placeholder: {
+        type: "BOOLEAN",
+        description: "Placeholder parameter. Always pass true.",
+      },
+    };
+    // Preserve existing required array, append _placeholder if not present
+    if (Array.isArray(result.required)) {
+      if (!result.required.includes("_placeholder")) {
+        result.required = [...(result.required as string[]), "_placeholder"];
+      }
+    } else {
+      result.required = ["_placeholder"];
+    }
   }
 
   return result;
@@ -151,10 +193,7 @@ export function isGemini25Model(model: string): boolean {
  */
 export function isImageGenerationModel(model: string): boolean {
   const lower = model.toLowerCase();
-  return (
-    lower.includes("image") ||
-    lower.includes("imagen")
-  );
+  return lower.includes("image") || lower.includes("imagen");
 }
 
 /**
@@ -179,13 +218,15 @@ export function buildGemini25ThinkingConfig(
 ): ThinkingConfig {
   return {
     includeThoughts,
-    ...(typeof thinkingBudget === "number" && thinkingBudget > 0 ? { thinkingBudget } : {}),
+    ...(typeof thinkingBudget === "number" && thinkingBudget > 0
+      ? { thinkingBudget }
+      : {}),
   };
 }
 
 /**
  * Image generation config for Gemini image models.
- * 
+ *
  * Supported aspect ratios: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"
  */
 export interface ImageConfig {
@@ -195,16 +236,27 @@ export interface ImageConfig {
 /**
  * Valid aspect ratios for image generation.
  */
-const VALID_ASPECT_RATIOS = ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"];
+const VALID_ASPECT_RATIOS = [
+  "1:1",
+  "2:3",
+  "3:2",
+  "3:4",
+  "4:3",
+  "4:5",
+  "5:4",
+  "9:16",
+  "16:9",
+  "21:9",
+];
 
 /**
  * Build image generation config for Gemini image models.
- * 
+ *
  * Configuration is read from environment variables:
  * - OPENCODE_IMAGE_ASPECT_RATIO: Aspect ratio (e.g., "16:9", "4:3")
- * 
+ *
  * Defaults to 1:1 aspect ratio if not specified.
- * 
+ *
  * Note: Resolution setting is not currently supported by the Antigravity API.
  */
 export function buildImageGenerationConfig(): ImageConfig {
@@ -215,7 +267,9 @@ export function buildImageGenerationConfig(): ImageConfig {
     return { aspectRatio };
   }
 
-  console.warn(`[gemini] Invalid aspect ratio "${aspectRatio}". Using default "1:1". Valid values: ${VALID_ASPECT_RATIOS.join(", ")}`);
+  console.warn(
+    `[gemini] Invalid aspect ratio "${aspectRatio}". Using default "1:1". Valid values: ${VALID_ASPECT_RATIOS.join(", ")}`,
+  );
 
   // Default to 1:1 square aspect ratio
   return { aspectRatio: "1:1" };
@@ -224,12 +278,13 @@ export function buildImageGenerationConfig(): ImageConfig {
 /**
  * Normalize tools for Gemini models.
  * Ensures tools have proper function-style format.
- * 
+ *
  * @returns Debug info about tool normalization
  */
-export function normalizeGeminiTools(
-  payload: RequestPayload,
-): { toolDebugMissing: number; toolDebugSummaries: string[] } {
+export function normalizeGeminiTools(payload: RequestPayload): {
+  toolDebugMissing: number;
+  toolDebugSummaries: string[];
+} {
   let toolDebugMissing = 0;
   const toolDebugSummaries: string[] = [];
 
@@ -237,106 +292,133 @@ export function normalizeGeminiTools(
     return { toolDebugMissing, toolDebugSummaries };
   }
 
-  payload.tools = (payload.tools as unknown[]).map((tool: unknown, toolIndex: number) => {
-    const t = tool as Record<string, unknown>;
+  payload.tools = (payload.tools as unknown[]).map(
+    (tool: unknown, toolIndex: number) => {
+      const t = tool as Record<string, unknown>;
 
-    // Skip normalization for Google Search tools (both old and new API)
-    if (t.googleSearch || t.googleSearchRetrieval) {
-      return t;
-    }
-
-    const newTool = { ...t };
-
-    const schemaCandidates = [
-      (newTool.function as Record<string, unknown> | undefined)?.input_schema,
-      (newTool.function as Record<string, unknown> | undefined)?.parameters,
-      (newTool.function as Record<string, unknown> | undefined)?.inputSchema,
-      (newTool.custom as Record<string, unknown> | undefined)?.input_schema,
-      (newTool.custom as Record<string, unknown> | undefined)?.parameters,
-      newTool.parameters,
-      newTool.input_schema,
-      newTool.inputSchema,
-    ].filter(Boolean);
-
-    const placeholderSchema: Record<string, unknown> = {
-      type: "OBJECT",
-      properties: {
-        _placeholder: {
-          type: "BOOLEAN",
-          description: "Placeholder. Always pass true.",
-        },
-      },
-      required: ["_placeholder"],
-    };
-
-    let schema = schemaCandidates[0] as Record<string, unknown> | undefined;
-    const schemaObjectOk = schema && typeof schema === "object" && !Array.isArray(schema);
-    if (!schemaObjectOk) {
-      schema = placeholderSchema;
-      toolDebugMissing += 1;
-    } else {
-      // Transform existing schema to Gemini-compatible format
-      schema = toGeminiSchema(schema) as Record<string, unknown>;
-    }
-
-    const nameCandidate =
-      newTool.name ||
-      (newTool.function as Record<string, unknown> | undefined)?.name ||
-      (newTool.custom as Record<string, unknown> | undefined)?.name ||
-      `tool-${toolIndex}`;
-
-    // Always update function.input_schema with transformed schema
-    if (newTool.function && schema) {
-      (newTool.function as Record<string, unknown>).input_schema = schema;
-    }
-
-    // Always update custom.input_schema with transformed schema
-    if (newTool.custom && schema) {
-      (newTool.custom as Record<string, unknown>).input_schema = schema;
-    }
-
-    // Create custom from function if missing
-    if (!newTool.custom && newTool.function) {
-      const fn = newTool.function as Record<string, unknown>;
-      newTool.custom = {
-        name: fn.name || nameCandidate,
-        description: fn.description,
-        input_schema: schema,
-      };
-    }
-
-    // Create custom if both missing
-    if (!newTool.custom && !newTool.function) {
-      newTool.custom = {
-        name: nameCandidate,
-        description: newTool.description,
-        input_schema: schema,
-      };
-
-      if (!newTool.parameters && !newTool.input_schema && !newTool.inputSchema) {
-        newTool.parameters = schema;
+      // Skip normalization for Google Search tools (both old and new API)
+      if (t.googleSearch || t.googleSearchRetrieval) {
+        return t;
       }
-    }
 
-    if (newTool.custom && !(newTool.custom as Record<string, unknown>).input_schema) {
-      (newTool.custom as Record<string, unknown>).input_schema = {
+      const newTool = { ...t };
+
+      const schemaCandidates = [
+        (newTool.function as Record<string, unknown> | undefined)?.input_schema,
+        (newTool.function as Record<string, unknown> | undefined)?.parameters,
+        (newTool.function as Record<string, unknown> | undefined)?.inputSchema,
+        (newTool.custom as Record<string, unknown> | undefined)?.input_schema,
+        (newTool.custom as Record<string, unknown> | undefined)?.parameters,
+        newTool.parameters,
+        newTool.input_schema,
+        newTool.inputSchema,
+      ].filter(Boolean);
+
+      const placeholderSchema: Record<string, unknown> = {
         type: "OBJECT",
-        properties: {},
+        properties: {
+          _placeholder: {
+            type: "BOOLEAN",
+            description: "Placeholder. Always pass true.",
+          },
+        },
+        required: ["_placeholder"],
       };
-      toolDebugMissing += 1;
-    }
 
-    toolDebugSummaries.push(
-      `idx=${toolIndex}, hasCustom=${!!newTool.custom}, customSchema=${!!(newTool.custom as Record<string, unknown> | undefined)?.input_schema}, hasFunction=${!!newTool.function}, functionSchema=${!!(newTool.function as Record<string, unknown> | undefined)?.input_schema}`,
-    );
+      let schema = schemaCandidates[0] as Record<string, unknown> | undefined;
+      const schemaObjectOk =
+        schema && typeof schema === "object" && !Array.isArray(schema);
+      if (!schemaObjectOk) {
+        schema = placeholderSchema;
+        toolDebugMissing += 1;
+      } else {
+        // Transform existing schema to Gemini-compatible format
+        schema = toGeminiSchema(schema) as Record<string, unknown>;
+      }
 
-    // Strip custom wrappers for Gemini; only function-style is accepted.
-    if (newTool.custom) {
-      delete newTool.custom;
-    }
+      const nameCandidate =
+        newTool.name ||
+        (newTool.function as Record<string, unknown> | undefined)?.name ||
+        (newTool.custom as Record<string, unknown> | undefined)?.name ||
+        `tool-${toolIndex}`;
 
-    return newTool;
-  });
+      // Always update function.input_schema with transformed schema
+      if (newTool.function && schema) {
+        (newTool.function as Record<string, unknown>).input_schema = schema;
+      }
+
+      // Always update custom.input_schema with transformed schema
+      if (newTool.custom && schema) {
+        (newTool.custom as Record<string, unknown>).input_schema = schema;
+      }
+
+      // Create custom from function if missing
+      if (!newTool.custom && newTool.function) {
+        const fn = newTool.function as Record<string, unknown>;
+        newTool.custom = {
+          name: fn.name || nameCandidate,
+          description: fn.description,
+          input_schema: schema,
+        };
+      }
+
+      // Create custom if both missing
+      if (!newTool.custom && !newTool.function) {
+        newTool.custom = {
+          name: nameCandidate,
+          description: newTool.description,
+          input_schema: schema,
+        };
+
+        if (
+          !newTool.parameters &&
+          !newTool.input_schema &&
+          !newTool.inputSchema
+        ) {
+          newTool.parameters = schema;
+        }
+      }
+
+      // Fix: Create function from custom if function is missing
+      // Without this, the schema is lost when custom is deleted below
+      if (newTool.custom && !newTool.function) {
+        const c = newTool.custom as Record<string, unknown>;
+        newTool.function = {
+          name: c.name || nameCandidate,
+          description: c.description,
+          input_schema: schema,
+        };
+      }
+
+      if (
+        newTool.custom &&
+        !(newTool.custom as Record<string, unknown>).input_schema
+      ) {
+        (newTool.custom as Record<string, unknown>).input_schema = {
+          type: "OBJECT",
+          properties: {
+            _placeholder: {
+              type: "BOOLEAN",
+              description: "Placeholder. Always pass true.",
+            },
+          },
+          required: ["_placeholder"],
+        };
+        toolDebugMissing += 1;
+      }
+
+      toolDebugSummaries.push(
+        `idx=${toolIndex}, hasCustom=${!!newTool.custom}, customSchema=${!!(newTool.custom as Record<string, unknown> | undefined)?.input_schema}, hasFunction=${!!newTool.function}, functionSchema=${!!(newTool.function as Record<string, unknown> | undefined)?.input_schema}`,
+      );
+
+      // Strip custom wrappers for Gemini; only function-style is accepted.
+      if (newTool.custom) {
+        delete newTool.custom;
+      }
+
+      return newTool;
+    },
+  );
 
   return { toolDebugMissing, toolDebugSummaries };
 }
@@ -373,7 +455,13 @@ export function applyGeminiTransforms(
   payload: RequestPayload,
   options: GeminiTransformOptions,
 ): GeminiTransformResult {
-  const { model, tierThinkingBudget, tierThinkingLevel, normalizedThinking, googleSearch } = options;
+  const {
+    model,
+    tierThinkingBudget,
+    tierThinkingLevel,
+    normalizedThinking,
+    googleSearch,
+  } = options;
 
   // 1. Apply thinking config if needed
   if (normalizedThinking) {
@@ -387,14 +475,18 @@ export function applyGeminiTransforms(
       );
     } else {
       // Gemini 2.5 and others use numeric budget
-      const thinkingBudget = tierThinkingBudget ?? normalizedThinking.thinkingBudget;
+      const thinkingBudget =
+        tierThinkingBudget ?? normalizedThinking.thinkingBudget;
       thinkingConfig = buildGemini25ThinkingConfig(
         normalizedThinking.includeThoughts ?? true,
         thinkingBudget,
       );
     }
 
-    const generationConfig = (payload.generationConfig ?? {}) as Record<string, unknown>;
+    const generationConfig = (payload.generationConfig ?? {}) as Record<
+      string,
+      unknown
+    >;
     generationConfig.thinkingConfig = thinkingConfig;
     payload.generationConfig = generationConfig;
   }
@@ -403,7 +495,7 @@ export function applyGeminiTransforms(
   // Uses the new googleSearch API for Gemini 2.0+ / Gemini 3 models
   // Note: The old googleSearchRetrieval with dynamicRetrievalConfig is deprecated
   // The new API doesn't support threshold - the model decides when to search automatically
-  if (googleSearch && googleSearch.mode === 'auto') {
+  if (googleSearch && googleSearch.mode === "auto") {
     const tools = (payload.tools as unknown[]) || [];
     if (!payload.tools) {
       payload.tools = tools;
@@ -438,13 +530,13 @@ export interface WrapToolsResult {
 
 /**
  * Wrap tools array in Gemini's required functionDeclarations format.
- * 
+ *
  * Gemini/Antigravity API expects:
  *   { tools: [{ functionDeclarations: [{ name, description, parameters }] }] }
- * 
+ *
  * NOT:
  *   { tools: [{ function: {...}, parameters: {...} }] }
- * 
+ *
  * The wrapper-level 'parameters' field causes:
  *   "Unknown name 'parameters' at 'request.tools[0]'"
  */
@@ -473,7 +565,9 @@ function isWebSearchTool(tool: Record<string, unknown>): boolean {
   return false;
 }
 
-export function wrapToolsAsFunctionDeclarations(payload: RequestPayload): WrapToolsResult {
+export function wrapToolsAsFunctionDeclarations(
+  payload: RequestPayload,
+): WrapToolsResult {
   if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
     return { wrappedFunctionCount: 0, passthroughToolCount: 0 };
   }
@@ -502,11 +596,23 @@ export function wrapToolsAsFunctionDeclarations(payload: RequestPayload): WrapTo
 
     if (tool.functionDeclarations) {
       if (Array.isArray(tool.functionDeclarations)) {
-        for (const decl of tool.functionDeclarations as Array<Record<string, unknown>>) {
+        for (const decl of tool.functionDeclarations as Array<
+          Record<string, unknown>
+        >) {
+          const declParams = (decl.parameters as Record<string, unknown>) || {
+            type: "OBJECT",
+            properties: {
+              _placeholder: {
+                type: "BOOLEAN",
+                description: "Placeholder. Always pass true.",
+              },
+            },
+            required: ["_placeholder"],
+          };
           functionDeclarations.push({
             name: String(decl.name || `tool-${functionDeclarations.length}`),
             description: String(decl.description || ""),
-            parameters: (decl.parameters as Record<string, unknown>) || { type: "OBJECT", properties: {} },
+            parameters: toGeminiSchema(declParams) as Record<string, unknown>,
           });
         }
       }
@@ -518,34 +624,37 @@ export function wrapToolsAsFunctionDeclarations(payload: RequestPayload): WrapTo
 
     const name = String(
       tool.name ||
-      fn?.name ||
-      custom?.name ||
-      `tool-${functionDeclarations.length}`
+        fn?.name ||
+        custom?.name ||
+        `tool-${functionDeclarations.length}`,
     );
 
     const description = String(
-      tool.description ||
-      fn?.description ||
-      custom?.description ||
-      ""
+      tool.description || fn?.description || custom?.description || "",
     );
 
-    const schema = (
-      fn?.input_schema ||
+    const rawSchema = (fn?.input_schema ||
       fn?.parameters ||
       fn?.inputSchema ||
       custom?.input_schema ||
       custom?.parameters ||
       tool.parameters ||
       tool.input_schema ||
-      tool.inputSchema ||
-      { type: "OBJECT", properties: {} }
-    ) as Record<string, unknown>;
+      tool.inputSchema || {
+        type: "OBJECT",
+        properties: {
+          _placeholder: {
+            type: "BOOLEAN",
+            description: "Placeholder. Always pass true.",
+          },
+        },
+        required: ["_placeholder"],
+      }) as Record<string, unknown>;
 
     functionDeclarations.push({
       name,
       description,
-      parameters: schema,
+      parameters: toGeminiSchema(rawSchema) as Record<string, unknown>,
     });
   }
 
@@ -566,7 +675,7 @@ export function wrapToolsAsFunctionDeclarations(payload: RequestPayload): WrapTo
     // Log warning: web search requested but can't be used with functions
     console.warn(
       "[gemini] web_search tool detected but cannot be combined with function declarations. " +
-      "Use the explicit google_search() tool call instead."
+        "Use the explicit google_search() tool call instead.",
     );
   }
 
@@ -574,6 +683,8 @@ export function wrapToolsAsFunctionDeclarations(payload: RequestPayload): WrapTo
 
   return {
     wrappedFunctionCount: functionDeclarations.length,
-    passthroughToolCount: passthroughTools.length + (hasWebSearchTool && functionDeclarations.length === 0 ? 1 : 0),
+    passthroughToolCount:
+      passthroughTools.length +
+      (hasWebSearchTool && functionDeclarations.length === 0 ? 1 : 0),
   };
 }


### PR DESCRIPTION
## Summary

Fixes 400 Bad Request errors when using tools with OpenCode/OhMyOpenCode.

## Problems Fixed

### 1. Schema loss when tool has 'custom' but no 'function'

When a tool only has 'custom' format (no 'function'), the schema was being set on 'custom.input_schema' but then 'custom' was deleted, leaving the tool with no schema.

**Fix**: Create 'function' from 'custom' before 'custom' is deleted.

### 2. Gemini rejects empty properties object

Tools with `properties: {}` (like `todoread`) cause 400 Bad Request because Gemini's strict protobuf validation rejects empty properties.

**Fix**: Add placeholder property when properties object is empty.

### 3. wrapToolsAsFunctionDeclarations bypasses toGeminiSchema

Schemas extracted in `wrapToolsAsFunctionDeclarations` were not being transformed through `toGeminiSchema()`, causing empty properties to slip through even after the fix in #2.

**Fix**: Call `toGeminiSchema()` on all extracted schemas and use proper placeholder fallbacks instead of `{ type: "OBJECT", properties: {} }`.

## Testing

Tested with oh-my-opencode using Gemini 3 Pro via Antigravity:
- `todoread` tool (no parameters) now works
- Custom-format tools now work
- All existing tools continue to work