### PR TITLE
fix: Gemini CLI compatibility and User-Agent version updates

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -84,11 +84,10 @@ export const GEMINI_CLI_HEADERS = {
 
 const ANTIGRAVITY_USER_AGENTS = [
   "antigravity/1.15.8 windows/amd64",
-  "antigravity/1.15.5 darwin/arm64",
-  "antigravity/1.15.2 linux/amd64",
-  "antigravity/1.15.0 windows/amd64",
-  "antigravity/1.14.5 darwin/amd64",
-  "antigravity/1.14.0 linux/arm64",
+  "antigravity/1.15.8 darwin/arm64",
+  "antigravity/1.15.8 linux/amd64",
+  "antigravity/1.15.8 darwin/amd64",
+  "antigravity/1.15.8 linux/arm64",
 ] as const;
 
 const ANTIGRAVITY_API_CLIENTS = [

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1334,7 +1334,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
             // Track capacity retries per endpoint to prevent infinite loops
             let capacityRetryCount = 0;
             let lastEndpointIndex = -1;
-            
+
             for (let i = 0; i < ANTIGRAVITY_ENDPOINT_FALLBACKS.length; i++) {
               // Reset capacity retry counter when switching to a new endpoint
               if (i !== lastEndpointIndex) {
@@ -1815,7 +1815,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   );
                 }
 
-                throw lastError || new Error("All Antigravity endpoints failed");
+                const endpointType = headerStyle === "gemini-cli" ? "Gemini CLI" : "Antigravity";
+                throw lastError || new Error(`All ${endpointType} endpoints failed (headerStyle=${headerStyle})`);
               }
 
               continue;

--- a/src/plugin/fingerprint.ts
+++ b/src/plugin/fingerprint.ts
@@ -19,7 +19,7 @@ const OS_VERSIONS: Record<string, string[]> = {
 
 const ARCHITECTURES = ["x64", "arm64"];
 
-const ANTIGRAVITY_VERSIONS = ["1.14.0", "1.14.5", "1.15.0", "1.15.2", "1.15.5", "1.15.8"];
+const ANTIGRAVITY_VERSIONS = ["1.15.8"];
 
 const IDE_TYPES = [
   "IDE_UNSPECIFIED",


### PR DESCRIPTION
# Fix: Gemini CLI compatibility and User-Agent version updates

## Problem

This PR addresses two critical issues affecting Gemini CLI models:

1. **User-Agent version rejection (Antigravity)**: Google's Antigravity API now requires User-Agent version `1.15.8`, causing "This version of Antigravity is no longer supported" errors with older versions.

2. **Gemini CLI 429 errors**: Gemini CLI endpoints are rejecting requests that include Antigravity-specific headers (fingerprints, device IDs, custom User-Agents), immediately returning 429 RESOURCE_EXHAUSTED errors even on fresh accounts.

**Related Issues:** #308, #309

## Root Causes

### Issue 1: Outdated User-Agent versions
- `ANTIGRAVITY_VERSIONS` array contained versions `1.10.0` through `1.15.8`, with old versions being randomly selected
- `ANTIGRAVITY_USER_AGENTS` array contained mixed versions from `1.14.0` to `1.15.8`
- Antigravity API now rejects any version below `1.15.8`

### Issue 2: Incorrect headers for Gemini CLI
- Fingerprint headers (with `antigravity/1.15.8` User-Agent, `X-Client-Device-Id`, etc.) were being applied to ALL requests, including Gemini CLI
- Gemini CLI endpoint expects clean headers like `google-api-nodejs-client/10.3.0`
- Google's API immediately rejects Gemini CLI requests with Antigravity-specific headers

## Solution

### 1. User-Agent Version Updates
- **src/plugin/fingerprint.ts**: Set `ANTIGRAVITY_VERSIONS = ["1.15.8"]` (only the latest version)
- **src/constants.ts**: Updated all `ANTIGRAVITY_USER_AGENTS` entries to use `1.15.8`
- **src/plugin/fingerprint.ts**: Updated hardcoded version in `collectCurrentFingerprint()` to `1.15.8`

### 2. Gemini CLI Header Fix (The Critical Fix)
- **src/plugin/request.ts**: Added `headerStyle` check to conditionally apply fingerprint headers
  - Antigravity requests (`headerStyle === "antigravity"`): Use fingerprints with device-specific User-Agents
  - Gemini CLI requests (`headerStyle === "gemini-cli"`): Use clean standard headers without fingerprinting
  - Explicitly delete `X-Goog-QuotaUser` and `X-Client-Device-Id` for Gemini CLI to prevent header leakage

### 3. Improved Error Messages
- **src/plugin.ts**: Updated error message to show whether Antigravity or Gemini CLI endpoints failed

## Changes

- `src/constants.ts`: Updated all User-Agent versions to 1.15.8, removed duplicate entry
- `src/plugin/fingerprint.ts`: Simplified version array to only use 1.15.8
- `src/plugin/request.ts`: Conditional fingerprint application based on headerStyle
- `src/plugin.ts`: Better error messaging

## Testing

Tested with:
- ✅ `gemini-3-pro-preview` (Gemini CLI)
- ✅ `gemini-3-flash-preview` (Gemini CLI)
- ✅ `gemini-2.5-flash` (Gemini CLI)
- ✅ `antigravity-claude-opus-4-5-thinking` (Antigravity with fingerprints)
- ✅ `antigravity-gemini-3-flash` (Antigravity with fingerprints)

Both Antigravity and Gemini CLI models now work correctly with appropriate headers for each endpoint type.

## Backward Compatibility

- ✅ Existing Antigravity models continue to work with fingerprint headers
- ✅ No breaking changes to the API or configuration
- ✅ Automatically detects and routes based on model name
