### PR TITLE
fix: use ANTIGRAVITY_VERSION in ANTIGRAVITY_HEADERS to prevent version mismatch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,8 +70,29 @@ export const GEMINI_CLI_ENDPOINT = ANTIGRAVITY_ENDPOINT_PROD;
  */
 export const ANTIGRAVITY_DEFAULT_PROJECT_ID = "rising-fact-p41fc";
 
+/**
+ * Antigravity version string - SINGLE SOURCE OF TRUTH.
+ * Update this value when a new version is needed.
+ * Used by ANTIGRAVITY_HEADERS, fingerprint.ts, and all version-dependent code.
+ * 
+ * @remarks
+ * This version MUST be kept in sync with Google's supported Antigravity versions.
+ * Using an outdated version will cause "This version of Antigravity is no longer supported" errors.
+ * 
+ * @see https://github.com/NoeFabris/opencode-antigravity-auth/issues/324
+ */
+export const ANTIGRAVITY_VERSION = "1.15.8" as const;
+
+/**
+ * Default headers for Antigravity API requests.
+ * 
+ * Uses ANTIGRAVITY_VERSION to ensure the User-Agent version stays in sync
+ * with the single source of truth, preventing "version no longer supported" errors.
+ * 
+ * @see https://github.com/NoeFabris/opencode-antigravity-auth/issues/324
+ */
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Antigravity/1.104.0 Chrome/138.0.7204.235 Electron/37.3.1 Safari/537.36",
+  "User-Agent": `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Antigravity/${ANTIGRAVITY_VERSION} Chrome/138.0.7204.235 Electron/37.3.1 Safari/537.36`,
   "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
   "Client-Metadata": '{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}',
 } as const;
@@ -81,13 +102,6 @@ export const GEMINI_CLI_HEADERS = {
   "X-Goog-Api-Client": "gl-node/22.18.0",
   "Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
 } as const;
-
-/**
- * Antigravity version string - SINGLE SOURCE OF TRUTH.
- * Update this value when a new version is needed.
- * Used by both constants.ts and fingerprint.ts
- */
-export const ANTIGRAVITY_VERSION = "1.15.8" as const;
 
 const ANTIGRAVITY_PLATFORMS = ["windows/amd64", "darwin/arm64", "linux/amd64", "darwin/amd64", "linux/arm64"] as const;
 


### PR DESCRIPTION
## Summary

Fixes the **"This version of Antigravity is no longer supported"** error by ensuring `ANTIGRAVITY_HEADERS` uses the dynamic `ANTIGRAVITY_VERSION` constant instead of a hardcoded outdated version.

Closes #324

## Problem

The `ANTIGRAVITY_HEADERS` constant was using a hardcoded version string `1.104.0`:

```typescript
export const ANTIGRAVITY_HEADERS = {
  "User-Agent": "...Antigravity/1.104.0...",  // ← Hardcoded outdated version
  ...
};
```

While `ANTIGRAVITY_VERSION` was already defined as `"1.15.8"` and used correctly in:
- `fingerprint.ts` via `generateFingerprint()`
- `ANTIGRAVITY_USER_AGENTS` array

This caused version mismatch when Google deprecated the old version, resulting in:
```
This version of Antigravity is no longer supported. Please update to receive the latest features!
```

## Root Cause

The `ANTIGRAVITY_HEADERS` constant was defined **before** `ANTIGRAVITY_VERSION` in the file, making it impossible to use the version constant. Additionally, the User-Agent string was hardcoded rather than using template literals.

## Changes

1. **Reordered declarations**: Moved `ANTIGRAVITY_VERSION` before `ANTIGRAVITY_HEADERS`
2. **Dynamic version injection**: Changed `ANTIGRAVITY_HEADERS["User-Agent"]` to use template literal:
   ```typescript
   "User-Agent": `Mozilla/5.0 ... Antigravity/${ANTIGRAVITY_VERSION} ...`
   ```
3. **Enhanced documentation**: Added JSDoc comments explaining:
   - Single source of truth pattern
   - Why this is important for preventing version drift
   - Reference to issue #324

## Impact

This fix ensures:
- All components using `ANTIGRAVITY_HEADERS` automatically get the correct version
- Future version updates only need to change `ANTIGRAVITY_VERSION` in one place
- No more "version no longer supported" errors from version mismatch

## Files Changed

- `src/constants.ts` - Reordered declarations and use dynamic version

## Testing

- [x] TypeScript compiles without errors
- [x] `ANTIGRAVITY_HEADERS["User-Agent"]` now includes version `1.15.8`
- [x] All existing imports of `ANTIGRAVITY_HEADERS` continue to work

## Related

- Issue: #324
- Affected components:
  - `src/plugin/project.ts` - Uses `ANTIGRAVITY_HEADERS` for `onboardManagedProject()`
  - `src/plugin/quota.ts` - Uses `ANTIGRAVITY_HEADERS` 
  - `src/plugin/search.ts` - Uses `ANTIGRAVITY_HEADERS`
  - `src/plugin/request.ts` - Uses `ANTIGRAVITY_HEADERS`
  - `src/antigravity/oauth.ts` - Uses `ANTIGRAVITY_HEADERS`