### PR TITLE
fix: auto-migrate Windows config from legacy path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.4.3",
+    "version": "1.4.4-beta.0",
     "description": "Google Antigravity IDE OAuth auth plugin for Opencode - access Gemini 3 Pro and Claude 4.5 using Google credentials",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Auto-migrates Windows config from legacy `%APPDATA%\opencode` to `~/.config/opencode`
- Attempts atomic `rename()` first, falls back to `copy()+delete()` for cross-filesystem moves
- Falls back to legacy path only if migration fails

## Problem

Previously, when config existed at the legacy Windows path, the plugin would read from there but never move it - leaving the config permanently misaligned with the standard path.

## Solution

Now on first detection, the file is moved to the correct location, aligning config across all platforms.