### PR TITLE
docs: fix oh-my-opencode integration config (use categories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ If you encounter errors during a session:
 {
   "google_auth": false,
   "agents": {
-    "multimodal-looker": { "model": "google/antigravity-gemini-3-flash" }
+    "multimodal-looker": { "model": "google/gemini-3-flash" }
   },
   "categories": {
-    "visual-engineering": { "model": "google/antigravity-gemini-3-pro" },
-    "writing": { "model": "google/antigravity-gemini-3-flash" }
+    "visual-engineering": { "model": "google/gemini-3-pro" },
+    "writing": { "model": "google/gemini-3-flash" }
   }
 }
 ```


### PR DESCRIPTION
# PR Title
docs: fix oh-my-opencode integration config (use categories)

# Description
Updates the "Using with Oh-My-OpenCode" section in README.md to use the correct `categories` configuration instead of the deprecated/invalid `agents` configuration for dynamic roles.

## Changes
- Changed configuration example to use `categories` for `visual-engineering` and `writing`.
- Retained `agents` configuration only for valid static agents (e.g., `multimodal-looker`).

## Rationale
Configuring `frontend-ui-ux-engineer` under `agents` is no longer supported in Oh-My-OpenCode and results in those settings being ignored. Users must configure the underlying categories (`visual-engineering`) to ensure their Antigravity models are used for frontend tasks.

## Diff
*Before:*
```json
{
  "agents": {
    "frontend-ui-ux-engineer": { "model": "google/gemini-3-pro" },
    "document-writer": { "model": "google/gemini-3-flash" }
  }
}
```

*After:*
```json
{
  "agents": {
    "multimodal-looker": { "model": "google/antigravity-gemini-3-flash" }
  },
  "categories": {
    "visual-engineering": { "model": "google/antigravity-gemini-3-pro" },
    "writing": { "model": "google/antigravity-gemini-3-flash" }
  }
}
```
