### PR TITLE
Fix excessive disk writes (3000+/sec) from project context auth updates

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1212,7 +1212,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
               continue;
             }
 
-            if (projectContext.auth !== authRecord) {
+            if (projectContext.auth.refresh !== authRecord.refresh || 
+                projectContext.auth.access !== authRecord.access) {
               accountManager.updateFromAuth(account, projectContext.auth);
               authRecord = projectContext.auth;
               try {


### PR DESCRIPTION
## Problem

Installing this plugin caused excessive disk writes (**3000+ per second**, **20-200 MB/s** sustained I/O) leading to SSD wear, high CPU usage (fseventsd at 70%), and system overheating on macOS (MacBook Air M4, 24GB RAM).

## Root Cause

Line 1215 in `src/plugin.ts` used **reference equality** (`!==`) to compare `projectContext.auth` objects, which always evaluated to `true` even when auth data was unchanged. This caused `saveToDisk()` to fire on **every streaming token** during AI responses.

The problematic code:
```typescript
if (projectContext.auth !== authRecord) {  // Always true - reference comparison
  await accountManager.saveToDisk();  // Fired thousands of times
}
```

## Fix

Changed to **value comparison** (checking `refresh` and `access` tokens) instead of reference equality:

```typescript
if (projectContext.auth.refresh !== authRecord.refresh || 
    projectContext.auth.access !== authRecord.access) {
  accountManager.updateFromAuth(account, projectContext.auth);
  authRecord = projectContext.auth;
  try {
    await accountManager.saveToDisk();
  } catch (error) {
    log.error("Failed to persist project context", { error: String(error) });
  }
}
```

This ensures the save only triggers when auth data **actually changes** (rare - typically 1-2 times when `managedProjectId` is provisioned).

## Impact

### Before Fix
- ❌ 3000+ writes/second
- ❌ 20-200 MB/s disk I/O
- ❌ System load 11-54
- ❌ fseventsd at 70% CPU
- ❌ File timestamp updating every millisecond

### After Fix
- ✅ File timestamp stable (constant for 10+ seconds)
- ✅ Disk I/O: 0.01-0.14 MB/s (nearly zero)
- ✅ Normal CPU usage
- ✅ Auth updates persist correctly
- ✅ Responsive performance

## Testing

Confirmed on macOS using:
- Activity Monitor (file modification timestamps)
- `iostat -d -w 1 -c 5 disk0` (disk I/O metrics)
- Streaming AI responses (no excessive writes during streaming)

The fix is surgical: **1 file changed**, net **+2 insertions -1 deletion**.