### PR TITLE
fix: respect opencode.jsonc in configure models flow

### DIFF
--- a/src/plugin/ui/auth-menu.ts
+++ b/src/plugin/ui/auth-menu.ts
@@ -54,7 +54,7 @@ export async function showAuthMenu(accounts: AccountInfo[]): Promise<AuthMenuAct
     { label: 'Add new account', value: { type: 'add' } },
     { label: 'Check quotas', value: { type: 'check' } },
     { label: 'Manage accounts (enable/disable)', value: { type: 'manage' } },
-    { label: 'Configure models in opencode.json', value: { type: 'configure-models' } },
+    { label: 'Configure models in opencode config', value: { type: 'configure-models' } },
 
     ...accounts.map(account => {
       const badge = getStatusBadge(account.status);


### PR DESCRIPTION
## Summary
- Fixes #377 by making `Configure models` reuse an existing `opencode.jsonc` instead of creating `opencode.json`.
- Adds JSONC parsing support (comments + trailing commas) when reading config before writing updated model definitions.
- Adds regression tests for JSONC parsing and default-path preference behavior.