### PR TITLE
feat: Add support for GPT 5.2, 5.1 Codex, Minimax M2.1 and Claude Opus 4.6 variants

### DIFF
--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -87,8 +87,24 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
     modalities: DEFAULT_MODALITIES,
     variants: {
       low: { thinkingConfig: { thinkingBudget: 8192 } },
+      medium: { thinkingConfig: { thinkingBudget: 16384 } },
       max: { thinkingConfig: { thinkingBudget: 32768 } },
     },
+  },
+  "antigravity-gpt-5-2": {
+    name: "GPT 5.2 (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "antigravity-gpt-5-1-codex": {
+    name: "GPT 5.1 Codex (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "antigravity-minimax-m2-1": {
+    name: "Minimax M2.1 (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
   },
   "gemini-2.5-flash": {
     name: "Gemini 2.5 Flash (Gemini CLI)",


### PR DESCRIPTION
This PR adds definitions for new models available via Antigravity:\n- GPT 5.2\n- GPT 5.1 Codex\n- Minimax M2.1\n- Claude Opus 4.6 (added medium thinking variant)