### PR TITLE
feat: auto-disable accounts requiring verification (403 Verify your account)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1568,9 +1568,9 @@ export const createAntigravityPlugin = (providerId: string) => async (
                       "error"
                     );
                     
-                    // Disable account and save
+                    // Disable account and save immediately (force persist before error)
                     account.enabled = false;
-                    accountManager.requestSaveToDisk();
+                    await accountManager.saveToDisk();
                     
                     // Refund token if consumed (hybrid strategy)
                     if (tokenConsumed) {


### PR DESCRIPTION
This PR adds logic to automatically disable accounts that return a 403 error with 'Verify your account' message.

**Problem:**
New/phone accounts can be flagged by Google, returning a 403 error requiring browser verification. This blocks the entire account rotation pool if not handled, as the plugin keeps retrying or using the blocked account.

**Solution:**
- Detects 403 status + 'Verify your account' body text.
- Sets `account.enabled = false` for the problematic account.
- Saves the disabled state to disk.
- Shows a toast notification to the user.
- Automatically rotates to the next available account.

This prevents workflow interruption while alerting the user to perform verification manually.