### PR TITLE
fix: allow gemini-3-pro-preview to use gemini-cli quota

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2744,7 +2744,7 @@ function getHeaderStyleFromUrl(urlString: string, family: ModelFamily): HeaderSt
     return "antigravity";
   }
   const { quotaPreference } = resolveModelWithTier(modelWithSuffix);
-  return quotaPreference === "gemini-cli" ? "antigravity" : (quotaPreference ?? "antigravity");
+  return quotaPreference ?? "antigravity";
 }
 
 function isExplicitQuotaFromUrl(urlString: string): boolean {

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -171,7 +171,7 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
   
   // All models default to Antigravity quota unless cli_first is enabled
   // Fallback to gemini-cli happens at the account rotation level when Antigravity is exhausted
-  const preferGeminiCli = options.cli_first === true && !isAntigravity && !isImageModel && !isClaudeModel;
+  const preferGeminiCli = (options.cli_first === true || modelWithoutQuota === "gemini-3-pro-preview") && !isAntigravity && !isImageModel && !isClaudeModel;
   const quotaPreference = preferGeminiCli ? "gemini-cli" as const : "antigravity" as const;
   const explicitQuota = isAntigravity || isImageModel;
 


### PR DESCRIPTION
This PR fixes an issue where selecting the `gemini-3-pro-preview` model (Gemini CLI) would still consume Antigravity quota because of a hardcoded override in `getHeaderStyleFromUrl`.

### Changes
1.  **`src/plugin/transform/model-resolver.ts`**: Updated `preferGeminiCli` logic to explicitly include `gemini-3-pro-preview` (when not using the `antigravity-` prefix).
2.  **`src/plugin.ts`**: Removed the logic that forced `quotaPreference` back to "antigravity" even when "gemini-cli" was resolved.

### Impact
Users can now correctly route `gemini-3-pro-preview` requests to the Gemini CLI quota pool by selecting that model, instead of being forced into the Antigravity pool.