### PR TITLE
fix: strip x-goog-user-project header for all headerStyles

### DIFF
--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -596,7 +596,7 @@ it("removes x-api-key header", () => {
       expect(headers.get("x-goog-user-project")).toBeNull();
     });
 
-    it("preserves x-goog-user-project header for gemini-cli headerStyle", () => {
+    it("removes x-goog-user-project header for gemini-cli headerStyle", () => {
       const result = prepareAntigravityRequest(
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
         { method: "POST", body: JSON.stringify({ contents: [] }), headers: { "x-goog-user-project": "my-project" } },
@@ -606,7 +606,7 @@ it("removes x-api-key header", () => {
         "gemini-cli"
       );
       const headers = result.init.headers as Headers;
-      expect(headers.get("x-goog-user-project")).toBe("my-project");
+      expect(headers.get("x-goog-user-project")).toBeNull();
     });
 
     it("identifies Claude models correctly", () => {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -655,13 +655,11 @@ export function prepareAntigravityRequest(
 
   headers.set("Authorization", `Bearer ${accessToken}`);
   headers.delete("x-api-key");
-  // Strip x-goog-user-project for antigravity headerStyle (Daily endpoint) to prevent 403 errors.
-  // This header is added by OpenCode/AI SDK but causes auth conflicts on sandbox endpoints.
-  // Models like claude-opus-4-6-thinking are only available on Daily, so this enables them to work.
-  // Keep the header for gemini-cli style (Prod endpoint) where it may be needed for billing/quota.
-  if (headerStyle === "antigravity") {
-    headers.delete("x-goog-user-project");
-  }
+  // Strip x-goog-user-project header to prevent 403 PERMISSION_DENIED errors.
+  // This header is added by OpenCode/AI SDK but causes auth conflicts on ALL endpoints
+  // (Daily, Autopush, Prod) when the user's GCP project doesn't have Cloud Code API enabled.
+  // Error: "Cloud Code Private API has not been used in project {user_project} before or it is disabled"
+  headers.delete("x-goog-user-project");
 
   const match = input.match(/\/models\/([^:]+):(\w+)/);
   if (!match) {


### PR DESCRIPTION
## Summary
- Strip `x-goog-user-project` header for **ALL headerStyles** (both antigravity and gemini-cli)
- This header causes 403 PERMISSION_DENIED on both Daily and Prod endpoints
- Add test coverage for both headerStyle behaviors

## Root Cause
The `x-goog-user-project` header causes **403 PERMISSION_DENIED** on ALL endpoints (Daily, Autopush, Prod) when the user's GCP project doesn't have Cloud Code API enabled. The error: *"Cloud Code Private API has not been used in project before or it is disabled"*

This fix strips the header unconditionally for all requests.

## Testing
Verified with live testing on 11 models:

| Endpoint | Without header | With header |
|----------|----------------|-------------|
| Daily | Various (200/429/503) | ALL 403 |
| Prod | Various (200/429/503) | ALL 403 |

## Changes
1. **src/plugin/request.ts**: Unconditional header deletion
   ```typescript
   headers.delete("x-goog-user-project");
   ```

2. **src/plugin/request.test.ts**: Updated tests
   - Removes `x-goog-user-project` header for antigravity headerStyle
   - Removes `x-goog-user-project` header for gemini-cli headerStyle

Fixes #410