### PR TITLE
fix: align gemini-cli headers with real Gemini CLI format

### DIFF
--- a/src/antigravity/oauth.ts
+++ b/src/antigravity/oauth.ts
@@ -135,7 +135,6 @@ async function fetchProjectID(accessToken: string): Promise<string> {
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/json",
     "User-Agent": GEMINI_CLI_HEADERS["User-Agent"],
-    "X-Goog-Api-Client": GEMINI_CLI_HEADERS["X-Goog-Api-Client"],
     "Client-Metadata": getAntigravityHeaders()["Client-Metadata"],
   };
 
@@ -214,7 +213,6 @@ export async function exchangeAntigravity(
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate, br",
         "User-Agent": GEMINI_CLI_HEADERS["User-Agent"],
-        "X-Goog-Api-Client": GEMINI_CLI_HEADERS["X-Goog-Api-Client"],
       },
       body: new URLSearchParams({
         client_id: ANTIGRAVITY_CLIENT_ID,
@@ -239,7 +237,6 @@ export async function exchangeAntigravity(
         headers: {
           Authorization: `Bearer ${tokenPayload.access_token}`,
           "User-Agent": GEMINI_CLI_HEADERS["User-Agent"],
-          "X-Goog-Api-Client": GEMINI_CLI_HEADERS["X-Goog-Api-Client"],
         },
       },
     );

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import {
+  GEMINI_CLI_HEADERS,
+  getRandomizedHeaders,
+  type HeaderSet,
+} from "./constants.ts"
+
+describe("GEMINI_CLI_HEADERS", () => {
+  it("contains only User-Agent with GeminiCLI format", () => {
+    expect(GEMINI_CLI_HEADERS).toEqual({
+      "User-Agent": "GeminiCLI/1.0.0/gemini-2.5-flash",
+    })
+  })
+
+  it("does not contain X-Goog-Api-Client", () => {
+    expect(GEMINI_CLI_HEADERS).not.toHaveProperty("X-Goog-Api-Client")
+  })
+
+  it("does not contain Client-Metadata", () => {
+    expect(GEMINI_CLI_HEADERS).not.toHaveProperty("Client-Metadata")
+  })
+})
+
+describe("getRandomizedHeaders", () => {
+  describe("gemini-cli style", () => {
+    it("returns only User-Agent header", () => {
+      const headers = getRandomizedHeaders("gemini-cli")
+      expect(headers).toHaveProperty("User-Agent")
+      expect(headers["X-Goog-Api-Client"]).toBeUndefined()
+      expect(headers["Client-Metadata"]).toBeUndefined()
+    })
+
+    it("returns a User-Agent in GeminiCLI format", () => {
+      const headers = getRandomizedHeaders("gemini-cli")
+      expect(headers["User-Agent"]).toMatch(/^GeminiCLI\/\d+\.\d+\.\d+\/gemini-2\.5-flash$/)
+    })
+
+    it("returns one of the expected GeminiCLI user agents", () => {
+      const expectedAgents = [
+        "GeminiCLI/1.2.0/gemini-2.5-flash",
+        "GeminiCLI/1.1.0/gemini-2.5-flash",
+        "GeminiCLI/1.0.0/gemini-2.5-flash",
+      ]
+      for (let i = 0; i < 20; i++) {
+        const headers = getRandomizedHeaders("gemini-cli")
+        expect(expectedAgents).toContain(headers["User-Agent"])
+      }
+    })
+  })
+
+  describe("antigravity style", () => {
+    it("returns all three headers", () => {
+      const headers = getRandomizedHeaders("antigravity")
+      expect(headers["User-Agent"]).toBeDefined()
+      expect(headers["X-Goog-Api-Client"]).toBeDefined()
+      expect(headers["Client-Metadata"]).toBeDefined()
+    })
+
+    it("returns User-Agent in antigravity format", () => {
+      const headers = getRandomizedHeaders("antigravity")
+      expect(headers["User-Agent"]).toMatch(/^antigravity\//)
+    })
+  })
+})
+
+describe("HeaderSet type", () => {
+  it("allows omitting X-Goog-Api-Client and Client-Metadata", () => {
+    const headers: HeaderSet = {
+      "User-Agent": "test",
+    }
+    expect(headers["User-Agent"]).toBe("test")
+    expect(headers["X-Goog-Api-Client"]).toBeUndefined()
+    expect(headers["Client-Metadata"]).toBeUndefined()
+  })
+
+  it("allows including all three headers", () => {
+    const headers: HeaderSet = {
+      "User-Agent": "test",
+      "X-Goog-Api-Client": "test-client",
+      "Client-Metadata": "test-metadata",
+    }
+    expect(headers["User-Agent"]).toBe("test")
+    expect(headers["X-Goog-Api-Client"]).toBe("test-client")
+    expect(headers["Client-Metadata"]).toBe("test-metadata")
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,9 +105,7 @@ export const ANTIGRAVITY_HEADERS = {
 } as const;
 
 export const GEMINI_CLI_HEADERS = {
-  "User-Agent": "google-api-nodejs-client/10.3.0",
-  "X-Goog-Api-Client": "gl-node/22.18.0",
-  "Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
+  "User-Agent": "GeminiCLI/1.0.0/gemini-2.5-flash",
 } as const;
 
 const ANTIGRAVITY_PLATFORMS = ["windows/amd64", "darwin/arm64", "linux/amd64", "darwin/amd64", "linux/arm64"] as const;
@@ -123,16 +121,9 @@ const ANTIGRAVITY_API_CLIENTS = [
 ] as const;
 
 const GEMINI_CLI_USER_AGENTS = [
-  "google-api-nodejs-client/9.15.1",
-  "google-api-nodejs-client/9.14.0",
-  "google-api-nodejs-client/9.13.0",
-] as const;
-
-const GEMINI_CLI_API_CLIENTS = [
-  "gl-node/22.17.0",
-  "gl-node/22.12.0",
-  "gl-node/20.18.0",
-  "gl-node/21.7.0",
+  "GeminiCLI/1.2.0/gemini-2.5-flash",
+  "GeminiCLI/1.1.0/gemini-2.5-flash",
+  "GeminiCLI/1.0.0/gemini-2.5-flash",
 ] as const;
 
 function randomFrom<T>(arr: readonly T[]): T {
@@ -141,16 +132,14 @@ function randomFrom<T>(arr: readonly T[]): T {
 
 export type HeaderSet = {
   "User-Agent": string;
-  "X-Goog-Api-Client": string;
-  "Client-Metadata": string;
+  "X-Goog-Api-Client"?: string;
+  "Client-Metadata"?: string;
 };
 
 export function getRandomizedHeaders(style: HeaderStyle): HeaderSet {
   if (style === "gemini-cli") {
     return {
       "User-Agent": randomFrom(GEMINI_CLI_USER_AGENTS),
-      "X-Goog-Api-Client": randomFrom(GEMINI_CLI_API_CLIENTS),
-      "Client-Metadata": GEMINI_CLI_HEADERS["Client-Metadata"],
     };
   }
   return {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import {
-  GEMINI_CLI_HEADERS,
   ANTIGRAVITY_ENDPOINT,
   GEMINI_CLI_ENDPOINT,
   EMPTY_SCHEMA_PLACEHOLDER_NAME,
@@ -1400,8 +1399,6 @@ export function prepareAntigravityRequest(
     // NO fingerprint headers, NO X-Goog-QuotaUser, NO X-Client-Device-Id
     // This mirrors exactly what https://github.com/jenslys/opencode-gemini-auth does
     headers.set("User-Agent", selectedHeaders["User-Agent"]);
-    headers.set("X-Goog-Api-Client", selectedHeaders["X-Goog-Api-Client"]);
-    headers.set("Client-Metadata", selectedHeaders["Client-Metadata"]);
   }
   // Optional debug header to observe tool normalization on the backend if surfaced
   if (toolDebugMissing > 0) {


### PR DESCRIPTION
## Summary

- Replaces fake `google-api-nodejs-client` User-Agent with real `GeminiCLI/{version}/{model}` format matching [gemini-cli source](https://github.com/google-gemini/gemini-cli)
- Removes `X-Goog-Api-Client` and `Client-Metadata` headers from gemini-cli requests (real CLI doesn't send these — they come from the `@google/genai` SDK layer)
- Updates all consumers in `request.ts` and `oauth.ts` to stop setting removed headers

## Changes

### `src/constants.ts`
- `GEMINI_CLI_HEADERS`: UA → `GeminiCLI/1.0.0/gemini-2.5-flash`, removed `X-Goog-Api-Client` and `Client-Metadata`
- `GEMINI_CLI_USER_AGENTS`: replaced with `GeminiCLI/1.2.0`, `1.1.0`, `1.0.0` versions
- Removed `GEMINI_CLI_API_CLIENTS` array entirely
- `HeaderSet` type: made `X-Goog-Api-Client` and `Client-Metadata` optional (antigravity still uses them)
- `getRandomizedHeaders("gemini-cli")`: now returns only `{ "User-Agent": ... }`

### `src/plugin/request.ts`
- Removed `headers.set()` calls for `X-Goog-Api-Client` and `Client-Metadata` in gemini-cli branch
- Removed unused `GEMINI_CLI_HEADERS` import

### `src/antigravity/oauth.ts`
- Removed `X-Goog-Api-Client` from all 3 call sites: `fetchProjectID`, token exchange, userinfo fetch

### `src/constants.test.ts` (new)
- Tests for `getRandomizedHeaders()` covering both header styles

## Testing
- Typecheck: clean
- All 853 tests pass
- Tested live against Daily/Autopush/Prod endpoints — confirmed quota and access unaffected