### PR TITLE
chore: remove antigravity-claude-opus-4-5-thinking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,7 @@ body:
         - antigravity-gemini-3-flash
         - antigravity-claude-sonnet-4-5
         - antigravity-claude-sonnet-4-5-thinking
-        - antigravity-claude-opus-4-5-thinking (deprecated)
+        - antigravity-claude-opus-4-5-thinking
         - antigravity-claude-opus-4-6-thinking
         - gemini-2.5-flash
         - gemini-2.5-pro


### PR DESCRIPTION
Fixes: https://github.com/NoeFabris/opencode-antigravity-auth/issues/424

 - Removed `antigravity-claude-opus-thinking-4-5` from `README.md`

