### PR TITLE
fix: continue auth flow after deleting last account

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,7 +11,7 @@ import {
 import { authorizeAntigravity, exchangeAntigravity } from "./antigravity/oauth";
 import type { AntigravityTokenExchangeResult } from "./antigravity/oauth";
 import { accessTokenExpired, isOAuthAuth, parseRefreshParts, formatRefreshParts } from "./plugin/auth";
-import { promptAddAnotherAccount, promptLoginMode, promptProjectId } from "./plugin/cli";
+import { promptAddAnotherAccount, promptLoginMode, promptProjectId, type LoginMenuResult } from "./plugin/cli";
 import { ensureProjectContext } from "./plugin/project";
 import {
   startAntigravityDebugRequest, 
@@ -2560,7 +2560,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
             let refreshAccountIndex: number | undefined;
             const existingStorage = await loadAccounts();
             if (existingStorage && existingStorage.accounts.length > 0) {
-              let menuResult;
+              let menuResult: LoginMenuResult = { mode: "cancel" };
               while (true) {
                 const now = Date.now();
                 const existingAccounts = existingStorage.accounts.map((acc, idx) => {
@@ -2970,18 +2970,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   log.error("Failed to clear stored Antigravity OAuth credentials", { error: String(storeError) });
                 }
 
-                return {
-                  url: "",
-                  instructions: "All accounts deleted. Run `opencode auth login` to reauthenticate.",
-                  method: "auto",
-                  callback: async () => ({
-                    type: "success",
-                    refresh: "",
-                    access: "",
-                    expires: 0,
-                    projectId: "",
-                  }),
-                };
+                menuResult = { mode: "fresh" };
+                startFresh = true;
               }
 
               if (menuResult.refreshAccountIndex !== undefined) {


### PR DESCRIPTION
## Summary
- Fix the Delete Account flow when the last account is removed by avoiding a synthetic OAuth success with empty credentials.
- After clearing stored auth, switch the login menu flow into fresh-login mode so the OAuth flow continues immediately.
- Add explicit `LoginMenuResult` typing for `menuResult` to keep strict typecheck clean.

## Verification
- `npm run typecheck`
- `npx vitest run src/plugin/accounts.test.ts src/plugin/persist-account-pool.test.ts`