### PR TITLE
fix: sync JSON schema with Zod config schema

### DIFF
--- a/assets/antigravity.schema.json
+++ b/assets/antigravity.schema.json
@@ -10,6 +10,15 @@
       "type": "boolean",
       "description": "Suppress most toast notifications (rate limit, account switching). Recovery toasts always shown. Env: OPENCODE_ANTIGRAVITY_QUIET=1"
     },
+    "toast_scope": {
+      "default": "root_only",
+      "type": "string",
+      "enum": [
+        "root_only",
+        "all"
+      ],
+      "description": "Controls which sessions show toast notifications. 'root_only' (default) shows in root session only, 'all' shows in all sessions."
+    },
     "debug": {
       "default": false,
       "type": "boolean",
@@ -154,6 +163,30 @@
       "default": true,
       "type": "boolean"
     },
+    "scheduling_mode": {
+      "default": "cache_first",
+      "type": "string",
+      "enum": [
+        "cache_first",
+        "balance",
+        "performance_first"
+      ],
+      "description": "Rate limit scheduling strategy. 'cache_first' (default) waits for cooldowns, 'balance' distributes across accounts, 'performance_first' picks fastest available."
+    },
+    "max_cache_first_wait_seconds": {
+      "default": 60,
+      "type": "number",
+      "minimum": 5,
+      "maximum": 300,
+      "description": "Maximum seconds to wait for a rate-limited account in cache_first mode before switching."
+    },
+    "failure_ttl_seconds": {
+      "default": 3600,
+      "type": "number",
+      "minimum": 60,
+      "maximum": 7200,
+      "description": "Time in seconds before a failed account is eligible for retry."
+    },
     "default_retry_after_seconds": {
       "default": 60,
       "type": "number",
@@ -165,6 +198,42 @@
       "type": "number",
       "minimum": 5,
       "maximum": 300
+    },
+    "request_jitter_max_ms": {
+      "default": 0,
+      "type": "number",
+      "minimum": 0,
+      "maximum": 5000,
+      "description": "Maximum random jitter in milliseconds added to outgoing requests to avoid thundering herd."
+    },
+    "soft_quota_threshold_percent": {
+      "default": 90,
+      "type": "number",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "Percentage of quota usage that triggers soft quota warnings and preemptive account switching."
+    },
+    "quota_refresh_interval_minutes": {
+      "default": 15,
+      "type": "number",
+      "minimum": 0,
+      "maximum": 60,
+      "description": "Interval in minutes between quota usage checks. Set to 0 to disable periodic checks."
+    },
+    "soft_quota_cache_ttl_minutes": {
+      "default": "auto",
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "auto"
+        },
+        {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 120
+        }
+      ],
+      "description": "TTL for cached soft quota data. 'auto' (default) calculates from refresh interval, or set a fixed number of minutes."
     },
     "health_score": {
       "type": "object",

--- a/script/build-schema.ts
+++ b/script/build-schema.ts
@@ -46,6 +46,26 @@ const envVarDescriptions: Record<string, string> = {
   proactive_refresh_check_interval_seconds:
     "Interval between proactive refresh checks in seconds.",
   auto_update: "Enable automatic plugin updates. Env: OPENCODE_ANTIGRAVITY_AUTO_UPDATE=1",
+  quota_fallback:
+    "Deprecated: accepted for backward compatibility but ignored at runtime. Gemini fallback between Antigravity and Gemini CLI is always enabled.",
+  cli_first:
+    "Prefer gemini-cli routing before Antigravity for Gemini models. When false (default), Antigravity is tried first and gemini-cli is fallback.",
+  toast_scope:
+    "Controls which sessions show toast notifications. 'root_only' (default) shows in root session only, 'all' shows in all sessions.",
+  scheduling_mode:
+    "Rate limit scheduling strategy. 'cache_first' (default) waits for cooldowns, 'balance' distributes across accounts, 'performance_first' picks fastest available.",
+  max_cache_first_wait_seconds:
+    "Maximum seconds to wait for a rate-limited account in cache_first mode before switching.",
+  failure_ttl_seconds:
+    "Time in seconds before a failed account is eligible for retry.",
+  request_jitter_max_ms:
+    "Maximum random jitter in milliseconds added to outgoing requests to avoid thundering herd.",
+  soft_quota_threshold_percent:
+    "Percentage of quota usage that triggers soft quota warnings and preemptive account switching.",
+  quota_refresh_interval_minutes:
+    "Interval in minutes between quota usage checks. Set to 0 to disable periodic checks.",
+  soft_quota_cache_ttl_minutes:
+    "TTL for cached soft quota data. 'auto' (default) calculates from refresh interval, or set a fixed number of minutes.",
 };
 
 const signatureCacheDescriptions: Record<string, string> = {


### PR DESCRIPTION
## Summary

Fixes #422 — `antigravity.schema.json` was missing 8 properties present in the Zod config schema. Since the schema has `additionalProperties: false`, IDEs (VS Code, JetBrains) flagged these valid config keys as errors.

## Changes

- **`assets/antigravity.schema.json`** — Regenerated from Zod schema via `build-schema.ts`. Now includes all 8 missing properties with correct types, enums, defaults, and descriptions.
- **`script/build-schema.ts`** — Added descriptions for `quota_fallback`, `cli_first`, and all 8 new properties to the `envVarDescriptions` map so they survive future regenerations.

## Missing Properties Added

| Property | Type | Default |
|----------|------|---------|
| `scheduling_mode` | `"cache_first" \| "balance" \| "performance_first"` | `"cache_first"` |
| `max_cache_first_wait_seconds` | `number (5–300)` | `60` |
| `failure_ttl_seconds` | `number (60–7200)` | `3600` |
| `toast_scope` | `"root_only" \| "all"` | `"root_only"` |
| `request_jitter_max_ms` | `number (0–5000)` | `0` |
| `soft_quota_threshold_percent` | `number (1–100)` | `90` |
| `quota_refresh_interval_minutes` | `number (0–60)` | `15` |
| `soft_quota_cache_ttl_minutes` | `"auto" \| number (1–120)` | `"auto"` |

Typecheck clean.