### PR TITLE
feat: Add interactive pause after checking quota

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2730,6 +2730,12 @@ export const createAntigravityPlugin = (providerId: string) => async (
                     await saveAccounts(existingStorage);
                   }
                   console.log("");
+                  console.log("\nPress Enter to return to the menu...");
+                  const { createInterface } = await import("node:readline/promises");
+                  const { stdin, stdout } = await import("node:process");
+                  const rl = createInterface({ input: stdin, output: stdout });
+                  await rl.question("");
+                  rl.close();
                   continue;
                 }
 


### PR DESCRIPTION
This PR modifies the quota check flow to wait for user input (Enter key) before returning to the main menu. Previously, the screen would clear immediately after displaying the quota bars, making it impossible for users to read the information. This change improves UX by allowing users to dismiss the quota view when ready.