### PR TITLE
fix: reduce excessive file writes from account state updates

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1699,8 +1699,6 @@ export const createAntigravityPlugin = (providerId: string) => async (
               accountManager.markToastShown(account.index);
             }
 
-            accountManager.requestSaveToDisk();
-
             let authRecord = accountManager.toAuthDetails(account);
 
             if (accessTokenExpired(authRecord)) {
@@ -2330,7 +2328,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   account.consecutiveFailures = 0;
                   getHealthTracker().recordSuccess(account.index);
                   accountManager.markAccountUsed(account.index);
-                  
+                  accountManager.requestSaveToDisk()
+
                   void triggerAsyncQuotaRefreshForAccount(
                     accountManager,
                     account.index,

--- a/src/plugin/accounts.test.ts
+++ b/src/plugin/accounts.test.ts
@@ -1087,7 +1087,7 @@ describe("AccountManager", () => {
 
       expect(saveSpy).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(1500);
+      await vi.advanceTimersByTimeAsync(5500);
 
       expect(saveSpy).toHaveBeenCalledTimes(1);
 
@@ -1112,7 +1112,7 @@ describe("AccountManager", () => {
 
       const flushPromise = manager.flushSaveToDisk();
 
-      await vi.advanceTimersByTimeAsync(1500);
+      await vi.advanceTimersByTimeAsync(5500);
       await flushPromise;
 
       expect(saveSpy).toHaveBeenCalledTimes(1);
@@ -1135,12 +1135,39 @@ describe("AccountManager", () => {
       const saveSpy = vi.spyOn(manager, "saveToDisk").mockResolvedValue();
 
       manager.requestSaveToDisk();
-      await vi.advanceTimersByTimeAsync(1500);
+      await vi.advanceTimersByTimeAsync(5500);
 
       expect(saveSpy).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(6000);
 
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+
+      saveSpy.mockRestore();
+    });
+
+    it("skips write when account state has not changed", async () => {
+      vi.useFakeTimers();
+
+      const stored: AccountStorageV4 = {
+        version: 4,
+        accounts: [
+          { refreshToken: "r1", projectId: "p1", addedAt: 1, lastUsed: 0 },
+        ],
+        activeIndex: 0,
+      };
+
+      const manager = new AccountManager(undefined, stored);
+      const saveSpy = vi.spyOn(manager, "saveToDisk").mockResolvedValue();
+
+      // First save — should write
+      manager.requestSaveToDisk();
+      await vi.advanceTimersByTimeAsync(5500);
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+
+      // Second save with no state change — should skip
+      manager.requestSaveToDisk();
+      await vi.advanceTimersByTimeAsync(5500);
       expect(saveSpy).toHaveBeenCalledTimes(1);
 
       saveSpy.mockRestore();


### PR DESCRIPTION
Fixes #436

## Problem

`saveAccounts()` writes `antigravity-accounts.json` far too frequently during normal operation. Each write acquires a `proper-lockfile` lock (mkdir/rmdir cycle), writes a temp file, and renames it — producing 4+ FS events per save. During active use with rate limit cycling, this fires dozens of times per minute, thrashing the config directory and overwhelming file watchers.

## Changes

1. **Remove unconditional `requestSaveToDisk()` on every API request** — the call at line 1702 fired on every request iteration even when no persistent state changed (only in-memory toast state was updated). Moved the save trigger to after `markAccountUsed()` on success, where `lastUsed` is actually persisted.

2. **Add snapshot deduplication** — `executeSave()` now compares a JSON snapshot of the current storage state against the last saved snapshot, skipping the write entirely when nothing changed. Uses the same `buildStorageState()` method as `saveToDisk()` to avoid duplication.

3. **Increase debounce from 1s → 5s** — rate limit reset times and quota cache are ephemeral state; a 5s window dramatically reduces writes during rate-limit storms while still being timely enough for persistence.