### PR TITLE
fix: reduce excessive file writes from account state updates

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1699,8 +1699,6 @@ export const createAntigravityPlugin = (providerId: string) => async (
               accountManager.markToastShown(account.index);
             }
 
-            accountManager.requestSaveToDisk();
-
             let authRecord = accountManager.toAuthDetails(account);
 
             if (accessTokenExpired(authRecord)) {
@@ -2330,7 +2328,8 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   account.consecutiveFailures = 0;
                   getHealthTracker().recordSuccess(account.index);
                   accountManager.markAccountUsed(account.index);
-                  
+                  accountManager.requestSaveToDisk();
+
                   void triggerAsyncQuotaRefreshForAccount(
                     accountManager,
                     account.index,

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -989,7 +989,7 @@ export class AccountManager {
         lastUsed: a.lastUsed,
         enabled: a.enabled,
         lastSwitchReason: a.lastSwitchReason,
-        rateLimitResetTimes: Object.keys(a.rateLimitResetTimes).length > 0 ? a.rateLimitResetTimes : undefined,
+        rateLimitResetTimes: Object.keys(a.rateLimitResetTimes).length > 0 ? { ...a.rateLimitResetTimes } : undefined,
         coolingDownUntil: a.coolingDownUntil,
         cooldownReason: a.cooldownReason,
         fingerprint: a.fingerprint,

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -312,6 +312,7 @@ export class AccountManager {
   private savePending = false;
   private saveTimeout: ReturnType<typeof setTimeout> | null = null;
   private savePromiseResolvers: Array<() => void> = [];
+  private lastSavedSnapshot: string | null = null;
 
   static async loadFromDisk(authFallback?: OAuthAuthDetails): Promise<AccountManager> {
     const stored = await loadAccounts();
@@ -973,11 +974,11 @@ export class AccountManager {
     return [...this.accounts];
   }
 
-  async saveToDisk(): Promise<void> {
+  private buildStorageState(): AccountStorageV4 {
     const claudeIndex = Math.max(0, this.currentAccountIndexByFamily.claude);
     const geminiIndex = Math.max(0, this.currentAccountIndexByFamily.gemini);
-    
-    const storage: AccountStorageV4 = {
+
+    return {
       version: 4,
       accounts: this.accounts.map((a) => ({
         email: a.email,
@@ -1005,9 +1006,13 @@ export class AccountManager {
         claude: claudeIndex,
         gemini: geminiIndex,
       },
-    };
+    }
+  }
 
-    await saveAccounts(storage);
+  async saveToDisk(): Promise<void> {
+    const state = this.buildStorageState();
+    await saveAccounts(state);
+    this.lastSavedSnapshot = JSON.stringify(state);
   }
 
   requestSaveToDisk(): void {
@@ -1017,7 +1022,7 @@ export class AccountManager {
     this.savePending = true;
     this.saveTimeout = setTimeout(() => {
       void this.executeSave();
-    }, 1000);
+    }, 5000);
   }
 
   async flushSaveToDisk(): Promise<void> {
@@ -1032,9 +1037,14 @@ export class AccountManager {
   private async executeSave(): Promise<void> {
     this.savePending = false;
     this.saveTimeout = null;
-    
+
     try {
-      await this.saveToDisk();
+      const state = this.buildStorageState();
+      const snapshot = JSON.stringify(state);
+      if (snapshot !== this.lastSavedSnapshot) {
+        await saveAccounts(state);
+        this.lastSavedSnapshot = snapshot;
+      }
     } catch {
       // best-effort persistence; avoid unhandled rejection from timer-driven saves
     } finally {


### PR DESCRIPTION
Fixes #436

Replaces #459 which I accidentally closed. This PR incorporates the review feedback from that PR (stale snapshot fix, semicolon consistency).

## Problem

`saveAccounts()` writes `antigravity-accounts.json` far too frequently during normal operation. Each write acquires a `proper-lockfile` lock (mkdir/rmdir cycle), writes a temp file, and renames it — producing 4+ FS events per save. During active use with rate limit cycling, this fires dozens of times per minute, thrashing the config directory and overwhelming file watchers.

## Changes

1. **Remove unconditional `requestSaveToDisk()` on every API request** — the call at line 1702 fired on every request iteration even when no persistent state changed (only in-memory toast state was updated). Moved the save trigger to after `markAccountUsed()` on success, where `lastUsed` is actually persisted.

2. **Add snapshot deduplication** — `executeSave()` now compares a JSON snapshot of the current storage state against the last saved snapshot, skipping the write entirely when nothing changed. The same `buildStorageState()` result is used for both the snapshot and the write to avoid stale-snapshot issues during async saves.

3. **Increase debounce from 1s → 5s** — rate limit reset times and quota cache are ephemeral state; a 5s window dramatically reduces writes during rate-limit storms while still being timely enough for persistence.