### PR TITLE
feat: add Gemini 3.1 Pro model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![X (Twitter)](https://img.shields.io/badge/X-@dopesalmon-000000?style=flat&logo=x)](https://x.com/dopesalmon)
 
-Enable Opencode to authenticate against **Antigravity** (Google's IDE) via OAuth so you can use Antigravity rate limits and access models like `gemini-3-pro` and `claude-opus-4-5-thinking` with your Google credentials.
+Enable Opencode to authenticate against **Antigravity** (Google's IDE) via OAuth so you can use Antigravity rate limits and access models like `gemini-3-pro` and `claude-sonnet-4-6-thinking` with your Google credentials.
 
 ## What You Get
 
-- **Claude Opus 4.5, Sonnet 4.5** and **Gemini 3 Pro/Flash** via Google OAuth
+- **Claude Sonnet 4.6, Opus 4.6** (plus 4.5 compatibility) and **Gemini 3 Pro/Flash** via Google OAuth
 - **Multi-account support** — add multiple Google accounts, auto-rotates when rate-limited
 - **Dual quota system** — access both Antigravity and Gemini CLI quotas from one plugin
 - **Thinking models** — extended thinking for Claude and Gemini 3 with configurable budgets
@@ -79,7 +79,7 @@ Install the opencode-antigravity-auth plugin and add the Antigravity model defin
 4. **Use it:**
 
    ```bash
-   opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --variant=max
+   opencode run "Hello" --model=google/antigravity-claude-sonnet-4-6-thinking --variant=max
    ```
 
 </details>
@@ -102,7 +102,7 @@ Install the opencode-antigravity-auth plugin and add the Antigravity model defin
 ### Verification
 
 ```bash
-opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --variant=max
+opencode run "Hello" --model=google/antigravity-claude-sonnet-4-6-thinking --variant=max
 ```
 
 </details>
@@ -118,9 +118,12 @@ opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --var
 | Model | Variants | Notes |
 |-------|----------|-------|
 | `antigravity-gemini-3-pro` | low, high | Gemini 3 Pro with thinking |
+| `antigravity-gemini-3.1-pro` | low, high | Gemini 3.1 Pro with thinking |
 | `antigravity-gemini-3-flash` | minimal, low, medium, high | Gemini 3 Flash with thinking |
 | `antigravity-claude-sonnet-4-5` | — | Claude Sonnet 4.5 |
-| `antigravity-claude-sonnet-4-5-thinking` | low, max | Claude Sonnet with extended thinking |
+| `antigravity-claude-sonnet-4-5-thinking` | low, max | Claude Sonnet 4.5 with extended thinking |
+| `antigravity-claude-sonnet-4-6` | — | Claude Sonnet 4.6 |
+| `antigravity-claude-sonnet-4-6-thinking` | low, max | Claude Sonnet 4.6 with extended thinking |
 | `antigravity-claude-opus-4-5-thinking` | low, max | Claude Opus 4.5 with extended thinking |
 | `antigravity-claude-opus-4-6-thinking` | low, max | Claude Opus 4.6 with extended thinking |
 
@@ -132,6 +135,7 @@ opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --var
 | `gemini-2.5-pro` | Gemini 2.5 Pro |
 | `gemini-3-flash-preview` | Gemini 3 Flash (preview) |
 | `gemini-3-pro-preview` | Gemini 3 Pro (preview) |
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro (preview) |
 
 > **Routing Behavior:**
 > - **Antigravity-first (default):** Gemini models use Antigravity quota across accounts.
@@ -142,7 +146,7 @@ opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --var
 
 **Using variants:**
 ```bash
-opencode run "Hello" --model=google/antigravity-claude-sonnet-4-5-thinking --variant=max
+opencode run "Hello" --model=google/antigravity-claude-sonnet-4-6-thinking --variant=max
 ```
 
 For details on variant configuration and thinking levels, see [docs/MODEL-VARIANTS.md](docs/MODEL-VARIANTS.md).
@@ -186,6 +190,20 @@ Add this to your `~/.config/opencode/opencode.json`:
         },
         "antigravity-claude-sonnet-4-5-thinking": {
           "name": "Claude Sonnet 4.5 Thinking (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
+        "antigravity-claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-sonnet-4-6-thinking": {
+          "name": "Claude Sonnet 4.6 Thinking (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {

--- a/docs/ANTIGRAVITY_API_SPEC.md
+++ b/docs/ANTIGRAVITY_API_SPEC.md
@@ -80,10 +80,14 @@ Accept: text/event-stream
 |------------|----------|------|--------|
 | Claude Sonnet 4.5 | `claude-sonnet-4-5` | Anthropic | ✅ Verified |
 | Claude Sonnet 4.5 Thinking | `claude-sonnet-4-5-thinking` | Anthropic | ✅ Verified |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | Anthropic | ⏳ Pending |
+| Claude Sonnet 4.6 Thinking | `claude-sonnet-4-6-thinking` | Anthropic | ⏳ Pending |
 | Claude Opus 4.5 Thinking | `claude-opus-4-5-thinking` | Anthropic | ✅ Verified |
 | Claude Opus 4.6 Thinking | `claude-opus-4-6-thinking` | Anthropic | ⏳ Pending |
 | Gemini 3 Pro High | `gemini-3-pro-high` | Google | ✅ Verified |
 | Gemini 3 Pro Low | `gemini-3-pro-low` | Google | ✅ Verified |
+| Gemini 3.1 Pro High | `gemini-3.1-pro-high` | Google | ⏳ Pending |
+| Gemini 3.1 Pro Low | `gemini-3.1-pro-low` | Google | ⏳ Pending |
 | GPT-OSS 120B Medium | `gpt-oss-120b-medium` | Other | ✅ Verified |
 
 ---

--- a/script/test-models.ts
+++ b/script/test-models.ts
@@ -10,12 +10,15 @@ const MODELS: ModelTest[] = [
   // Gemini CLI (direct Google API)
   { model: "google/gemini-3-flash-preview", category: "gemini-cli" },
   { model: "google/gemini-3-pro-preview", category: "gemini-cli" },
+  { model: "google/gemini-3.1-pro-preview", category: "gemini-cli" },
   { model: "google/gemini-2.5-pro", category: "gemini-cli" },
   { model: "google/gemini-2.5-flash", category: "gemini-cli" },
 
   // Antigravity Gemini
   { model: "google/antigravity-gemini-3-pro-low", category: "antigravity-gemini" },
   { model: "google/antigravity-gemini-3-pro-high", category: "antigravity-gemini" },
+  { model: "google/antigravity-gemini-3.1-pro-low", category: "antigravity-gemini" },
+  { model: "google/antigravity-gemini-3.1-pro-high", category: "antigravity-gemini" },
   { model: "google/antigravity-gemini-3-flash", category: "antigravity-gemini" },
 
   // Antigravity Claude
@@ -23,6 +26,10 @@ const MODELS: ModelTest[] = [
   { model: "google/antigravity-claude-sonnet-4-5-thinking-low", category: "antigravity-claude" },
   { model: "google/antigravity-claude-sonnet-4-5-thinking-medium", category: "antigravity-claude" },
   { model: "google/antigravity-claude-sonnet-4-5-thinking-high", category: "antigravity-claude" },
+  { model: "google/antigravity-claude-sonnet-4-6", category: "antigravity-claude" },
+  { model: "google/antigravity-claude-sonnet-4-6-thinking-low", category: "antigravity-claude" },
+  { model: "google/antigravity-claude-sonnet-4-6-thinking-medium", category: "antigravity-claude" },
+  { model: "google/antigravity-claude-sonnet-4-6-thinking-high", category: "antigravity-claude" },
   { model: "google/antigravity-claude-opus-4-5-thinking-low", category: "antigravity-claude" },
   { model: "google/antigravity-claude-opus-4-5-thinking-medium", category: "antigravity-claude" },
   { model: "google/antigravity-claude-opus-4-5-thinking-high", category: "antigravity-claude" },

--- a/src/plugin/config/models.test.ts
+++ b/src/plugin/config/models.test.ts
@@ -19,17 +19,26 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       "antigravity-claude-opus-4-6-thinking",
       "antigravity-claude-sonnet-4-5",
       "antigravity-claude-sonnet-4-5-thinking",
+      "antigravity-claude-sonnet-4-6",
+      "antigravity-claude-sonnet-4-6-thinking",
       "antigravity-gemini-3-flash",
       "antigravity-gemini-3-pro",
+      "antigravity-gemini-3.1-pro",
       "gemini-2.5-flash",
       "gemini-2.5-pro",
       "gemini-3-flash-preview",
       "gemini-3-pro-preview",
+      "gemini-3.1-pro-preview",
     ]);
   });
 
   it("defines Gemini 3 variants for Antigravity models", () => {
     expect(getModel("antigravity-gemini-3-pro").variants).toEqual({
+      low: { thinkingLevel: "low" },
+      high: { thinkingLevel: "high" },
+    });
+
+    expect(getModel("antigravity-gemini-3.1-pro").variants).toEqual({
       low: { thinkingLevel: "low" },
       high: { thinkingLevel: "high" },
     });
@@ -44,6 +53,11 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
 
   it("defines thinking budget variants for Claude thinking models", () => {
     expect(getModel("antigravity-claude-sonnet-4-5-thinking").variants).toEqual({
+      low: { thinkingConfig: { thinkingBudget: 8192 } },
+      max: { thinkingConfig: { thinkingBudget: 32768 } },
+    });
+
+    expect(getModel("antigravity-claude-sonnet-4-6-thinking").variants).toEqual({
       low: { thinkingConfig: { thinkingBudget: 8192 } },
       max: { thinkingConfig: { thinkingBudget: 32768 } },
     });

--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -47,6 +47,15 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
       high: { thinkingLevel: "high" },
     },
   },
+  "antigravity-gemini-3.1-pro": {
+    name: "Gemini 3.1 Pro (Antigravity)",
+    limit: { context: 1048576, output: 65535 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      low: { thinkingLevel: "low" },
+      high: { thinkingLevel: "high" },
+    },
+  },
   "antigravity-gemini-3-flash": {
     name: "Gemini 3 Flash (Antigravity)",
     limit: { context: 1048576, output: 65536 },
@@ -65,6 +74,20 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
   },
   "antigravity-claude-sonnet-4-5-thinking": {
     name: "Claude Sonnet 4.5 Thinking (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      low: { thinkingConfig: { thinkingBudget: 8192 } },
+      max: { thinkingConfig: { thinkingBudget: 32768 } },
+    },
+  },
+  "antigravity-claude-sonnet-4-6": {
+    name: "Claude Sonnet 4.6 (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "antigravity-claude-sonnet-4-6-thinking": {
+    name: "Claude Sonnet 4.6 Thinking (Antigravity)",
     limit: { context: 200000, output: 64000 },
     modalities: DEFAULT_MODALITIES,
     variants: {
@@ -107,6 +130,11 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
   },
   "gemini-3-pro-preview": {
     name: "Gemini 3 Pro Preview (Gemini CLI)",
+    limit: { context: 1048576, output: 65535 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "gemini-3.1-pro-preview": {
+    name: "Gemini 3.1 Pro Preview (Gemini CLI)",
     limit: { context: 1048576, output: 65535 },
     modalities: DEFAULT_MODALITIES,
   },

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -735,6 +735,18 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3-pro-low");
       });
 
+      it("transforms gemini-3.1-pro-preview to gemini-3.1-pro-low for antigravity headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
+      });
+
       it("transforms gemini-3-flash to gemini-3-flash-preview for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent",
@@ -757,6 +769,18 @@ it("removes x-api-key header", () => {
           "gemini-cli"
         );
         expect(result.effectiveModel).toBe("gemini-3-pro-preview");
+      });
+
+      it("transforms gemini-3.1-pro-low to gemini-3.1-pro-preview for gemini-cli headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-low:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.1-pro-preview");
       });
 
       it("keeps non-Gemini-3 models unchanged regardless of headerStyle", () => {


### PR DESCRIPTION
Adds Gemini 3.1 Pro support for Antigravity and Gemini CLI model paths. Changes include new model definitions (antigravity-gemini-3.1-pro and gemini-3.1-pro-preview), resolver updates for gemini-3.x routing and tier transforms, additional tests, and docs updates. Reference: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/ Validation run: npx vitest run src/plugin/config/models.test.ts src/plugin/transform/model-resolver.test.ts src/plugin/request.test.ts src/plugin/transform/gemini.test.ts ; npm run typecheck