### PR TITLE
feat: Add Claude Sonnet 4.6 Thinking model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ opencode run "Hello" --model=google/antigravity-claude-opus-4-6-thinking --varia
 | `antigravity-gemini-3.1-pro` | low, high | Gemini 3.1 Pro with thinking (rollout-dependent) |
 | `antigravity-gemini-3-flash` | minimal, low, medium, high | Gemini 3 Flash with thinking |
 | `antigravity-claude-sonnet-4-6` | — | Claude Sonnet 4.6 |
+| `antigravity-claude-sonnet-4-6-thinking` | low, medium, high | Claude Sonnet 4.6 with extended thinking |
 | `antigravity-claude-opus-4-6-thinking` | low, max | Claude Opus 4.6 with extended thinking |
 
 **Gemini CLI quota** (separate from Antigravity; used when `cli_first` is true or as fallback):
@@ -193,6 +194,15 @@ Add this to your `~/.config/opencode/opencode.json`:
           "name": "Claude Sonnet 4.6 (Antigravity)",
           "limit": { "context": 200000, "output": 64000 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "antigravity-claude-sonnet-4-6-thinking": {
+          "name": "Claude Sonnet 4.6 Thinking (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
         },
         "antigravity-claude-opus-4-6-thinking": {
           "name": "Claude Opus 4.6 Thinking (Antigravity)",

--- a/docs/ANTIGRAVITY_API_SPEC.md
+++ b/docs/ANTIGRAVITY_API_SPEC.md
@@ -79,6 +79,7 @@ Accept: text/event-stream
 | Model Name | Model ID | Type | Status |
 |------------|----------|------|--------|
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | Anthropic | ✅ Verified |
+| Claude Sonnet 4.6 Thinking | `claude-sonnet-4-6-thinking` | Anthropic | ⏳ Pending Rollout |
 | Claude Opus 4.6 Thinking | `claude-opus-4-6-thinking` | Anthropic | ✅ Verified |
 | Gemini 3 Pro High | `gemini-3-pro-high` | Google | ✅ Verified |
 | Gemini 3 Pro Low | `gemini-3-pro-low` | Google | ✅ Verified |

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -108,6 +108,15 @@ Claude models use token-based thinking budgets:
 
 ```json
 {
+  "antigravity-claude-sonnet-4-6-thinking": {
+    "name": "Claude Sonnet 4.6 Thinking (Antigravity)",
+    "limit": { "context": 200000, "output": 64000 },
+    "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+    "variants": {
+      "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+      "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+    }
+  },
   "antigravity-claude-opus-4-6-thinking": {
     "name": "Claude Opus 4.6 Thinking (Antigravity)",
     "limit": { "context": 200000, "output": 64000 },

--- a/src/plugin/config/models.test.ts
+++ b/src/plugin/config/models.test.ts
@@ -17,6 +17,7 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
     expect(modelNames).toEqual([
       "antigravity-claude-opus-4-6-thinking",
       "antigravity-claude-sonnet-4-6",
+      "antigravity-claude-sonnet-4-6-thinking",
       "antigravity-gemini-3-flash",
       "antigravity-gemini-3-pro",
       "antigravity-gemini-3.1-pro",

--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -72,6 +72,15 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
     limit: { context: 200000, output: 64000 },
     modalities: DEFAULT_MODALITIES,
   },
+  "antigravity-claude-sonnet-4-6-thinking": {
+    name: "Claude Sonnet 4.6 Thinking (Antigravity)",
+    limit: { context: 200000, output: 64000 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      low: { thinkingConfig: { thinkingBudget: 8192 } },
+      max: { thinkingConfig: { thinkingBudget: 32768 } },
+    },
+  },
   "antigravity-claude-opus-4-6-thinking": {
     name: "Claude Opus 4.6 Thinking (Antigravity)",
     limit: { context: 200000, output: 64000 },

--- a/src/plugin/transform/claude.test.ts
+++ b/src/plugin/transform/claude.test.ts
@@ -60,6 +60,7 @@ describe("isClaudeThinkingModel", () => {
 
   it("returns true for prefixed thinking models", () => {
     expect(isClaudeThinkingModel("antigravity-claude-sonnet-4-5-thinking")).toBe(true);
+    expect(isClaudeThinkingModel("antigravity-claude-sonnet-4-6-thinking")).toBe(true);
     expect(isClaudeThinkingModel("google/claude-opus-4-5-thinking-high")).toBe(true);
   });
 

--- a/src/plugin/transform/cross-model-sanitizer.test.ts
+++ b/src/plugin/transform/cross-model-sanitizer.test.ts
@@ -13,6 +13,7 @@ describe("cross-model-sanitizer", () => {
     it("identifies Claude models", () => {
       expect(getModelFamily("claude-opus-4-6-thinking-medium")).toBe("claude");
       expect(getModelFamily("claude-sonnet-4-6")).toBe("claude");
+      expect(getModelFamily("claude-sonnet-4-6-thinking")).toBe("claude");
       expect(getModelFamily("claude-opus-4-6-thinking-low")).toBe("claude");
     });
 

--- a/src/plugin/transform/gemini.test.ts
+++ b/src/plugin/transform/gemini.test.ts
@@ -612,8 +612,9 @@ describe("transform/gemini", () => {
       expect(isImageGenerationModel("gemini-2.5-flash")).toBe(false);
     });
 
-    it("returns false for claude-sonnet-4-6", () => {
+    it("returns false for claude-sonnet-4-6 and thinking variants", () => {
       expect(isImageGenerationModel("claude-sonnet-4-6")).toBe(false);
+      expect(isImageGenerationModel("claude-sonnet-4-6-thinking")).toBe(false);
     });
   });
 

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -126,6 +126,14 @@ describe("resolveModelWithTier", () => {
       expect(result.isThinkingModel).toBe(true);
       expect(result.quotaPreference).toBe("antigravity");
     });
+
+    it("antigravity-claude-sonnet-4-6-thinking gets default max budget (32768)", () => {
+      const result = resolveModelWithTier("antigravity-claude-sonnet-4-6-thinking");
+      expect(result.actualModel).toBe("claude-sonnet-4-6-thinking");
+      expect(result.thinkingBudget).toBe(32768);
+      expect(result.isThinkingModel).toBe(true);
+      expect(result.quotaPreference).toBe("antigravity");
+    });
   });
 
   describe("Claude Sonnet 4.6 (non-thinking)", () => {

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -52,6 +52,9 @@ export const MODEL_ALIASES: Record<string, string> = {
   "gemini-claude-opus-4-6-thinking-low": "claude-opus-4-6-thinking",
   "gemini-claude-opus-4-6-thinking-medium": "claude-opus-4-6-thinking",
   "gemini-claude-opus-4-6-thinking-high": "claude-opus-4-6-thinking",
+  "gemini-claude-sonnet-4-6-thinking-low": "claude-sonnet-4-6-thinking",
+  "gemini-claude-sonnet-4-6-thinking-medium": "claude-sonnet-4-6-thinking",
+  "gemini-claude-sonnet-4-6-thinking-high": "claude-sonnet-4-6-thinking",
   "gemini-claude-sonnet-4-6": "claude-sonnet-4-6",
 
   // Image generation models - only gemini-3-pro-image is available via Antigravity API


### PR DESCRIPTION
## Summary

Adds support for `antigravity-claude-sonnet-4-6-thinking` model with extended thinking capabilities.

## Changes

- Added `antigravity-claude-sonnet-4-6-thinking` model definition with `thinkingConfig` variants (matching existing Opus 4.6 Thinking pattern):
  - `low`: `thinkingBudget: 8192`
  - `max`: `thinkingBudget: 32768`

## Model Definition

```typescript
"antigravity-claude-sonnet-4-6-thinking": {
  name: "Claude Sonnet 4.6 Thinking (Antigravity)",
  limit: { context: 200000, output: 64000 },
  modalities: { input: ["text", "image", "pdf"], output: ["text"] },
  variants: {
    low: { thinkingConfig: { thinkingBudget: 8192 } },
    max: { thinkingConfig: { thinkingBudget: 32768 } },
  },
}
```

## Variant Options

Following the existing `antigravity-claude-opus-4-6-thinking` pattern:
- **No variant** (dynamic): Model decides thinking budget automatically
- **`low`**: `thinkingBudget: 8192`
- **`max`**: `thinkingBudget: 32768`

## Evidence

Google Antigravity now supports Claude Sonnet 4.6 (thinking) as an official reasoning model:
- https://antigravity.google/docs/models

## Use Case

Enables users to use thinking capabilities with Sonnet 4.6:

```json
"unspecified-low": {
  "model": "google/antigravity-claude-sonnet-4-6-thinking",
  "variant": "low"
}
```

## Related

- Closes #495
- Anthropic's Claude Sonnet 4.6 announcement: https://www.anthropic.com/claude/sonnet

## Testing

- Model definition compiles without errors
- Variants map correctly to API parameters
- Request transformation handles thinking budget correctly