### PR TITLE
Bump Antigravity version fallback to 1.19.4

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,7 @@ export const GEMINI_CLI_ENDPOINT = ANTIGRAVITY_ENDPOINT_PROD;
  */
 export const ANTIGRAVITY_DEFAULT_PROJECT_ID = "rising-fact-p41fc";
 
-export const ANTIGRAVITY_VERSION_FALLBACK = "1.18.3";
+export const ANTIGRAVITY_VERSION_FALLBACK = "1.19.4";
 let antigravityVersion = ANTIGRAVITY_VERSION_FALLBACK;
 let versionLocked = false;
 


### PR DESCRIPTION
## Summary

Bump the hardcoded Antigravity version fallback from `1.18.3` to `1.19.4`.

This fallback is used when the plugin cannot reach the auto-updater API or changelog page (e.g., offline environments, strict firewalls). Having an up-to-date fallback ensures requests aren't rejected with "version no longer supported" errors.

## Changes

- `src/constants.ts`: Update `ANTIGRAVITY_VERSION_FALLBACK` from `"1.18.3"` to `"1.19.4"`

---

**Note:** The test at `src/plugin/version.test.ts:31` checks `>= 1.18.0`, so it will continue to pass with 1.19.4.