### PR TITLE
fix(auth): recover stale lockfile and prevent false 0-added login count

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3118,7 +3118,18 @@ export const createAntigravityPlugin = (providerId: string) => async (
               } catch (error) {
                 const reason = error instanceof Error ? error.message : String(error);
                 const lockPath = `${getStoragePath()}.lock`;
-                const isLockError = /ELOCKED|EEXIST/i.test(reason);
+                const errorCode = (
+                  typeof error === "object" &&
+                  error !== null &&
+                  "code" in error &&
+                  typeof (error as { code?: unknown }).code === "string"
+                )
+                  ? (error as { code: string }).code
+                  : undefined;
+                const isLockError =
+                  errorCode === "ELOCKED" ||
+                  errorCode === "EEXIST" ||
+                  /ELOCKED|EEXIST/i.test(reason);
                 const lockGuidance = isLockError
                   ? ` Storage lock at ${lockPath} may be held by another process (lock directory). ` +
                     `Retry after current operation finishes. If the lock persists and ${lockPath} exists as a file, remove that file and retry.`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3185,6 +3185,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                 actualAccountCount = finalStorage.accounts.length;
               }
             } catch {
+              // Fall back to accounts.length if we can't read storage
             }
 
             const successMessage = refreshAccountIndex !== undefined

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3122,6 +3122,19 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   `failed to persist account data (${reason}). ` +
                   `Check and remove stale lock file if needed: ${lockPath}`;
                 console.warn(`[opencode-antigravity-auth] ${accountPersistenceWarning}`);
+                try {
+                  const compactReason = reason.length > 120 ? `${reason.slice(0, 117)}...` : reason;
+                  const toastMessage = /ELOCKED|EEXIST/i.test(reason)
+                    ? `Authenticated, but account was not saved due to storage lock. Remove stale lock file and retry: ${lockPath}`
+                    : `Authenticated, but account was not saved: ${compactReason}`;
+                  await client.tui.showToast({
+                    body: {
+                      message: toastMessage,
+                      variant: "error",
+                    },
+                  });
+                } catch {
+                }
               }
 
               if (refreshAccountIndex !== undefined) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3120,12 +3120,13 @@ export const createAntigravityPlugin = (providerId: string) => async (
                 const lockPath = `${getStoragePath()}.lock`;
                 const accountPersistenceWarning =
                   `failed to persist account data (${reason}). ` +
-                  `Check and remove stale lock file if needed: ${lockPath}`;
+                  `Storage appears locked at ${lockPath}. Retry after current operation finishes. ` +
+                  `If the lock persists and ${lockPath} is a file, remove it and retry.`;
                 console.warn(`[opencode-antigravity-auth] ${accountPersistenceWarning}`);
                 try {
                   const compactReason = reason.length > 120 ? `${reason.slice(0, 117)}...` : reason;
                   const toastMessage = /ELOCKED|EEXIST/i.test(reason)
-                    ? `Authenticated, but account was not saved due to storage lock. Remove stale lock file and retry: ${lockPath}`
+                    ? `Authenticated, but account was not saved because storage is locked. Retry in a moment. If the lock persists and ${lockPath} is a file, remove it and retry.`
                     : `Authenticated, but account was not saved: ${compactReason}`;
                   await client.tui.showToast({
                     body: {
@@ -3133,7 +3134,9 @@ export const createAntigravityPlugin = (providerId: string) => async (
                       variant: "error",
                     },
                   });
-                } catch {
+                } catch (toastError) {
+                  // Toast display is best-effort; auth succeeded even if notification fails.
+                  console.warn("[opencode-antigravity-auth] Failed to show account persistence toast:", toastError);
                 }
               }
 
@@ -3154,9 +3157,6 @@ export const createAntigravityPlugin = (providerId: string) => async (
                 }
               } catch {
                 // Fall back to accounts.length if we can't read storage
-              }
-              if (currentAccountCount <= 0 && accounts.length > 0) {
-                currentAccountCount = accounts.length;
               }
 
               const addAnother = await promptAddAnotherAccount(currentAccountCount);
@@ -3182,9 +3182,6 @@ export const createAntigravityPlugin = (providerId: string) => async (
                 actualAccountCount = finalStorage.accounts.length;
               }
             } catch {
-            }
-            if (actualAccountCount <= 0 && accounts.length > 0) {
-              actualAccountCount = accounts.length;
             }
 
             const successMessage = refreshAccountIndex !== undefined

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,7 +39,7 @@ import {
 import { EmptyResponseError } from "./plugin/errors";
 import { AntigravityTokenRefreshError, refreshAccessToken } from "./plugin/token";
 import { startOAuthListener, type OAuthListener } from "./plugin/server";
-import { clearAccounts, loadAccounts, saveAccounts, saveAccountsReplace } from "./plugin/storage";
+import { clearAccounts, getStoragePath, loadAccounts, saveAccounts, saveAccountsReplace } from "./plugin/storage";
 import { AccountManager, type ModelFamily, parseRateLimitReason, calculateBackoffMs, computeSoftQuotaCacheTtlMs } from "./plugin/accounts";
 import { createAutoUpdateCheckerHook } from "./hooks/auto-update-checker";
 import { loadConfig, initRuntimeConfig, type AntigravityConfig } from "./plugin/config";
@@ -3115,7 +3115,13 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   const isFirstAccount = accounts.length === 1;
                   await persistAccountPool([result], isFirstAccount && startFresh);
                 }
-              } catch {
+              } catch (error) {
+                const reason = error instanceof Error ? error.message : String(error);
+                const lockPath = `${getStoragePath()}.lock`;
+                const accountPersistenceWarning =
+                  `failed to persist account data (${reason}). ` +
+                  `Check and remove stale lock file if needed: ${lockPath}`;
+                console.warn(`[opencode-antigravity-auth] ${accountPersistenceWarning}`);
               }
 
               if (refreshAccountIndex !== undefined) {
@@ -3130,11 +3136,14 @@ export const createAntigravityPlugin = (providerId: string) => async (
               let currentAccountCount = accounts.length;
               try {
                 const currentStorage = await loadAccounts();
-                if (currentStorage) {
+                if (currentStorage && currentStorage.accounts.length > 0) {
                   currentAccountCount = currentStorage.accounts.length;
                 }
               } catch {
                 // Fall back to accounts.length if we can't read storage
+              }
+              if (currentAccountCount <= 0 && accounts.length > 0) {
+                currentAccountCount = accounts.length;
               }
 
               const addAnother = await promptAddAnotherAccount(currentAccountCount);
@@ -3156,10 +3165,13 @@ export const createAntigravityPlugin = (providerId: string) => async (
             let actualAccountCount = accounts.length;
             try {
               const finalStorage = await loadAccounts();
-              if (finalStorage) {
+              if (finalStorage && finalStorage.accounts.length > 0) {
                 actualAccountCount = finalStorage.accounts.length;
               }
             } catch {
+            }
+            if (actualAccountCount <= 0 && accounts.length > 0) {
+              actualAccountCount = accounts.length;
             }
 
             const successMessage = refreshAccountIndex !== undefined

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3118,15 +3118,18 @@ export const createAntigravityPlugin = (providerId: string) => async (
               } catch (error) {
                 const reason = error instanceof Error ? error.message : String(error);
                 const lockPath = `${getStoragePath()}.lock`;
+                const isLockError = /ELOCKED|EEXIST/i.test(reason);
+                const lockGuidance = isLockError
+                  ? ` Storage lock at ${lockPath} may be held by another process (lock directory). ` +
+                    `Retry after current operation finishes. If the lock persists and ${lockPath} exists as a file, remove that file and retry.`
+                  : "";
                 const accountPersistenceWarning =
-                  `failed to persist account data (${reason}). ` +
-                  `Storage appears locked at ${lockPath}. Retry after current operation finishes. ` +
-                  `If the lock persists and ${lockPath} is a file, remove it and retry.`;
+                  `failed to persist account data (${reason}).${lockGuidance}`;
                 console.warn(`[opencode-antigravity-auth] ${accountPersistenceWarning}`);
                 try {
                   const compactReason = reason.length > 120 ? `${reason.slice(0, 117)}...` : reason;
-                  const toastMessage = /ELOCKED|EEXIST/i.test(reason)
-                    ? `Authenticated, but account was not saved because storage is locked. Retry in a moment. If the lock persists and ${lockPath} is a file, remove it and retry.`
+                  const toastMessage = isLockError
+                    ? `Authenticated, but account was not saved because storage is locked. Another process may hold a lock directory. Retry in a moment; if ${lockPath} persists as a file, remove the file and retry.`
                     : `Authenticated, but account was not saved: ${compactReason}`;
                   await client.tui.showToast({
                     body: {

--- a/src/plugin/storage.test.ts
+++ b/src/plugin/storage.test.ts
@@ -3,6 +3,7 @@ import {
   deduplicateAccountsByEmail,
   migrateV2ToV3,
   loadAccounts,
+  saveAccounts,
   type AccountMetadata,
   type AccountStorage,
 } from "./storage";
@@ -14,9 +15,13 @@ import {
   appendFileSync,
 } from "node:fs";
 
+const { lockMock } = vi.hoisted(() => ({
+  lockMock: vi.fn(),
+}));
+
 vi.mock("proper-lockfile", () => ({
   default: {
-    lock: vi.fn().mockResolvedValue(vi.fn().mockResolvedValue(undefined)),
+    lock: lockMock,
   },
 }));
 
@@ -219,6 +224,7 @@ vi.mock("node:fs", async () => {
       writeFile: vi.fn(),
       mkdir: vi.fn().mockResolvedValue(undefined),
       access: vi.fn().mockResolvedValue(undefined),
+      lstat: vi.fn(),
       unlink: vi.fn(),
       rename: vi.fn().mockResolvedValue(undefined),
       appendFile: vi.fn(),
@@ -228,6 +234,58 @@ vi.mock("node:fs", async () => {
     writeFileSync: vi.fn(),
     appendFileSync: vi.fn(),
   };
+});
+
+describe("saveAccounts lock recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lockMock.mockReset();
+    lockMock.mockResolvedValue(vi.fn().mockResolvedValue(undefined));
+  });
+
+  it("recovers from a legacy .lock file and retries lock acquisition", async () => {
+    const lockError = new Error("lock held") as NodeJS.ErrnoException;
+    lockError.code = "ELOCKED";
+    const release = vi.fn().mockResolvedValue(undefined);
+    lockMock.mockRejectedValueOnce(lockError).mockResolvedValueOnce(release);
+
+    vi.mocked(fs.lstat).mockResolvedValue({
+      isFile: () => true,
+    } as unknown as import("node:fs").Stats);
+    vi.mocked(fs.unlink).mockResolvedValue(undefined);
+    vi.mocked(fs.readFile).mockRejectedValue({ code: "ENOENT" });
+
+    await saveAccounts({
+      version: 4,
+      accounts: [{ refreshToken: "r1", addedAt: 1, lastUsed: 1 }],
+      activeIndex: 0,
+    });
+
+    expect(lockMock).toHaveBeenCalledTimes(2);
+    expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("antigravity-accounts.json.lock"));
+    expect(fs.rename).toHaveBeenCalled();
+  });
+
+  it("does not remove active lock directories", async () => {
+    const lockError = new Error("lock held") as NodeJS.ErrnoException;
+    lockError.code = "ELOCKED";
+    lockMock.mockRejectedValue(lockError);
+    vi.mocked(fs.lstat).mockResolvedValue({
+      isFile: () => false,
+    } as unknown as import("node:fs").Stats);
+    vi.mocked(fs.readFile).mockRejectedValue({ code: "ENOENT" });
+
+    await expect(
+      saveAccounts({
+        version: 4,
+        accounts: [{ refreshToken: "r1", addedAt: 1, lastUsed: 1 }],
+        activeIndex: 0,
+      }),
+    ).rejects.toThrow("lock held");
+
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(fs.unlink).not.toHaveBeenCalled();
+  });
 });
 
 describe("Storage Migration", () => {
@@ -371,6 +429,8 @@ describe("Storage Migration", () => {
   describe("loadAccounts migration integration", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      lockMock.mockReset();
+      lockMock.mockResolvedValue(vi.fn().mockResolvedValue(undefined));
     });
 
     it("migrates V2 storage on load and persists V4", async () => {

--- a/src/plugin/storage.test.ts
+++ b/src/plugin/storage.test.ts
@@ -286,6 +286,31 @@ describe("saveAccounts lock recovery", () => {
     expect(lockMock).toHaveBeenCalledTimes(1);
     expect(fs.unlink).not.toHaveBeenCalled();
   });
+
+  it("re-throws original lock error when unlink fails", async () => {
+    const lockError = new Error("lock held") as NodeJS.ErrnoException;
+    lockError.code = "ELOCKED";
+    lockMock.mockRejectedValue(lockError);
+    vi.mocked(fs.lstat).mockResolvedValue({
+      isFile: () => true,
+    } as unknown as import("node:fs").Stats);
+
+    const unlinkError = new Error("permission denied") as NodeJS.ErrnoException;
+    unlinkError.code = "EPERM";
+    vi.mocked(fs.unlink).mockRejectedValue(unlinkError);
+    vi.mocked(fs.readFile).mockRejectedValue({ code: "ENOENT" });
+
+    await expect(
+      saveAccounts({
+        version: 4,
+        accounts: [{ refreshToken: "r1", addedAt: 1, lastUsed: 1 }],
+        activeIndex: 0,
+      }),
+    ).rejects.toThrow("lock held");
+
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("Storage Migration", () => {

--- a/src/plugin/storage.ts
+++ b/src/plugin/storage.ts
@@ -399,7 +399,7 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
       throw error;
     }
 
-    return lockfile.lock(path, LOCK_OPTIONS);
+    return await lockfile.lock(path, LOCK_OPTIONS);
   }
 }
 

--- a/src/plugin/storage.ts
+++ b/src/plugin/storage.ts
@@ -357,6 +357,52 @@ const LOCK_OPTIONS = {
   },
 };
 
+function getLockPath(path: string): string {
+  return `${path}.lock`;
+}
+
+async function tryRecoverLegacyLockfile(path: string): Promise<boolean> {
+  const lockPath = getLockPath(path);
+
+  try {
+    const lockStat = await fs.lstat(lockPath);
+    if (!lockStat.isFile()) {
+      return false;
+    }
+
+    await fs.unlink(lockPath);
+    log.warn("Removed legacy lock file that blocked account storage lock", { lockPath });
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      log.warn("Failed to remove legacy account storage lock file", {
+        lockPath,
+        error: String(error),
+      });
+    }
+    return false;
+  }
+}
+
+async function acquireFileLock(path: string): Promise<() => Promise<void>> {
+  try {
+    return await lockfile.lock(path, LOCK_OPTIONS);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ELOCKED" && code !== "EEXIST") {
+      throw error;
+    }
+
+    const recovered = await tryRecoverLegacyLockfile(path);
+    if (!recovered) {
+      throw error;
+    }
+
+    return lockfile.lock(path, LOCK_OPTIONS);
+  }
+}
+
 /**
  * Ensures the file has secure permissions (0600) on POSIX systems.
  * This is a best-effort operation and ignores errors on Windows/unsupported FS.
@@ -386,7 +432,7 @@ async function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
   await ensureFileExists(path);
   let release: (() => Promise<void>) | null = null;
   try {
-    release = await lockfile.lock(path, LOCK_OPTIONS);
+    release = await acquireFileLock(path);
     return await fn();
   } finally {
     if (release) {


### PR DESCRIPTION
## Summary
- recover from stale legacy `antigravity-accounts.json.lock` file artifacts that can block `proper-lockfile` with `ELOCKED`
- make auth login persistence failures visible instead of silently swallowed (console warning + user-visible toast)
- avoid misleading `(0 added)` prompt/success count when OAuth succeeded in-memory but persistence temporarily failed

## Root Cause
A stale file lock (`~/.config/opencode/antigravity-accounts.json.lock`) can remain from legacy/failed lock state. When present, storage lock acquisition can fail with `ELOCKED`, account persistence fails, and login UI can show `0 added` even after successful OAuth exchange.

## Changes
- `src/plugin/storage.ts`
  - add `acquireFileLock()` wrapper around `proper-lockfile.lock(...)`
  - on `ELOCKED`/`EEXIST`, attempt one-time recovery by deleting only a file-based `.lock` artifact and retry lock
  - never delete lock directories (active lock format)
- `src/plugin.ts`
  - log warning with lock file path when account persistence fails during login
  - show an error toast when account persistence fails (includes stale-lock guidance for lock-related errors)
  - use in-memory fallback for added-account count when persisted storage is empty/unavailable
- `src/plugin/storage.test.ts`
  - add regression tests for stale lock-file recovery and non-file lock safety

## Related Issues
- Refs #513 (can't add account)
- Refs #436 (lock-file behavior context)

## Validation
- `npm run typecheck`
- `npx vitest run src/plugin/storage.test.ts src/plugin/persist-account-pool.test.ts`

Both pass in the isolated worktree.