### PR TITLE
fix: resolve gemini-3.1-pro 404 by using bare model name instead of tier suffix (#510)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ CLIProxyAPI/
 LLM-API-Key-Proxy/
 opencode/
 opencode-better-antigravity-auth/
+.opencode/

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1048,7 +1048,7 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3-pro-low");
       });
 
-      it("transforms gemini-3.1-pro-preview to gemini-3.1-pro-low for antigravity headerStyle", () => {
+      it("transforms gemini-3.1-pro-preview to gemini-3.1-pro for antigravity headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1057,10 +1057,10 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
-        expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
+        expect(result.effectiveModel).toBe("gemini-3.1-pro");
       });
 
-      it("transforms gemini-3.1-pro-preview-customtools to gemini-3.1-pro-low for antigravity headerStyle", () => {
+      it("transforms gemini-3.1-pro-preview-customtools to gemini-3.1-pro for antigravity headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview-customtools:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1069,7 +1069,7 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
-        expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
+        expect(result.effectiveModel).toBe("gemini-3.1-pro");
       });
 
       it("transforms gemini-3-flash to gemini-3-flash-preview for gemini-cli headerStyle", () => {

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -111,11 +111,6 @@ describe("resolveModelWithTier", () => {
       expect(result.thinkingLevel).toBe("medium");
     });
 
-    it("antigravity-gemini-3.1-pro uses bare model name (no -low suffix)", () => {
-      const result = resolveModelWithTier("antigravity-gemini-3.1-pro");
-      expect(result.actualModel).toBe("gemini-3.1-pro");
-      expect(result.thinkingLevel).toBe("low");
-    });
   });
 
   describe("Issue #510: Gemini 3.1 Pro uses bare name (no tier suffix)", () => {

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -111,10 +111,44 @@ describe("resolveModelWithTier", () => {
       expect(result.thinkingLevel).toBe("medium");
     });
 
-    it("antigravity-gemini-3.1-pro gets default -low model", () => {
+    it("antigravity-gemini-3.1-pro uses bare model name (no -low suffix)", () => {
       const result = resolveModelWithTier("antigravity-gemini-3.1-pro");
-      expect(result.actualModel).toBe("gemini-3.1-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
       expect(result.thinkingLevel).toBe("low");
+    });
+  });
+
+  describe("Issue #510: Gemini 3.1 Pro uses bare name (no tier suffix)", () => {
+    it("antigravity-gemini-3.1-pro resolves to bare gemini-3.1-pro", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.1-pro");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
+      expect(result.thinkingLevel).toBe("low");
+      expect(result.quotaPreference).toBe("antigravity");
+      expect(result.explicitQuota).toBe(true);
+    });
+
+    it("antigravity-gemini-3.1-pro-high strips tier from name, sets thinkingLevel", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.1-pro-high");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
+      expect(result.thinkingLevel).toBe("high");
+    });
+
+    it("antigravity-gemini-3.1-pro-low strips tier from name, sets thinkingLevel", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.1-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
+      expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("regression: antigravity-gemini-3-pro still appends -low (3.0 behavior unchanged)", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3-pro");
+      expect(result.actualModel).toBe("gemini-3-pro-low");
+      expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("regression: antigravity-gemini-3-pro-high still keeps -high (3.0 behavior unchanged)", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3-pro-high");
+      expect(result.actualModel).toBe("gemini-3-pro-high");
+      expect(result.thinkingLevel).toBe("high");
     });
   });
 
@@ -227,6 +261,16 @@ describe("resolveModelWithVariant", () => {
       expect(result.configSource).toBe("variant");
     });
 
+    it("maps budget to thinkingLevel for Gemini 3.1 Pro without tier suffix in model name", () => {
+      const result = resolveModelWithVariant("antigravity-gemini-3.1-pro", {
+        thinkingBudget: 32000,
+      });
+      expect(result.actualModel).toBe("gemini-3.1-pro");
+      expect(result.thinkingLevel).toBe("high");
+      expect(result.thinkingBudget).toBeUndefined();
+      expect(result.configSource).toBe("variant");
+    });
+
     it("uses budget directly for non-Gemini 3 models", () => {
       const result = resolveModelWithVariant("gemini-2.5-pro", {
         thinkingBudget: 20000,
@@ -273,15 +317,15 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("transforms gemini-3.1-pro-preview to gemini-3.1-pro-low for antigravity", () => {
+    it("transforms gemini-3.1-pro-preview to gemini-3.1-pro for antigravity", () => {
       const result = resolveModelForHeaderStyle("gemini-3.1-pro-preview", "antigravity");
-      expect(result.actualModel).toBe("gemini-3.1-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("transforms gemini-3.1-pro-preview-customtools to gemini-3.1-pro-low for antigravity", () => {
+    it("transforms gemini-3.1-pro-preview-customtools to gemini-3.1-pro for antigravity", () => {
       const result = resolveModelForHeaderStyle("gemini-3.1-pro-preview-customtools", "antigravity");
-      expect(result.actualModel).toBe("gemini-3.1-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
       expect(result.quotaPreference).toBe("antigravity");
     });
   });
@@ -299,8 +343,8 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
-    it("transforms gemini-3.1-pro-low to gemini-3.1-pro-preview for gemini-cli", () => {
-      const result = resolveModelForHeaderStyle("gemini-3.1-pro-low", "gemini-cli");
+    it("transforms gemini-3.1-pro to gemini-3.1-pro-preview for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.1-pro", "gemini-cli");
       expect(result.actualModel).toBe("gemini-3.1-pro-preview");
       expect(result.quotaPreference).toBe("gemini-cli");
     });

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -63,6 +63,7 @@ const TIER_REGEX = /-(minimal|low|medium|high)$/;
 const QUOTA_PREFIX_REGEX = /^antigravity-/i;
 const GEMINI_3_PRO_REGEX = /^gemini-3(?:\.\d+)?-pro/i;
 const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
+const GEMINI_3_BASE_PRO_REGEX = /^gemini-3-pro/i;
 
 // ANTIGRAVITY_ONLY_MODELS removed - all models now default to antigravity
 
@@ -138,6 +139,15 @@ function isGemini3FlashModel(model: string): boolean {
 }
 
 /**
+ * Checks if model is specifically gemini-3-pro (3.0 only, no minor version).
+ * Only gemini-3-pro supports tier suffixes in model name (gemini-3-pro-low/high).
+ * Models like gemini-3.1-pro use bare name + thinkingLevel parameter instead.
+ */
+function isGemini3BaseProModel(model: string): boolean {
+  return GEMINI_3_BASE_PRO_REGEX.test(model);
+}
+
+/**
  * Resolves a model name with optional tier suffix and quota prefix to its actual API model name
  * and corresponding thinking configuration.
  *
@@ -183,10 +193,17 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
   const isGemini3Pro = isGemini3ProModel(modelWithoutQuota);
   const isGemini3Flash = isGemini3FlashModel(modelWithoutQuota);
   
+  const isBaseProOnly = isGemini3BaseProModel(modelWithoutQuota);
+
   let antigravityModel = modelWithoutQuota;
   if (skipAlias) {
-    if (isGemini3Pro && !tier && !isImageModel) {
+    if (isBaseProOnly && !tier && !isImageModel) {
+      // Only gemini-3-pro (3.0) uses tier suffix in model name
       antigravityModel = `${modelWithoutQuota}-low`;
+    } else if ((isGemini3Pro && !isBaseProOnly) && tier) {
+      // gemini-3.1+-pro with explicit tier: strip tier suffix, use bare name
+      // (thinkingLevel parameter handles the tier)
+      antigravityModel = baseName;
     } else if (isGemini3Flash && tier) {
       antigravityModel = baseName;
     }
@@ -324,12 +341,13 @@ export function resolveModelForHeaderStyle(
       .replace(/-preview$/i, "")
       .replace(/^antigravity-/i, "");
     
-    const isGemini3Pro = isGemini3ProModel(transformedModel);
+    const isBaseProOnly = isGemini3BaseProModel(transformedModel);
     const hasTierSuffix = /-(low|medium|high)$/i.test(transformedModel);
     const isImageModel = IMAGE_GENERATION_MODELS.test(transformedModel);
     
-    // Don't add tier suffix to image models - they don't support thinking
-    if (isGemini3Pro && !hasTierSuffix && !isImageModel) {
+    // Only gemini-3-pro (3.0) uses tier suffix in model name for Antigravity
+    // gemini-3.1+-pro uses bare name + thinkingLevel parameter
+    if (isBaseProOnly && !hasTierSuffix && !isImageModel) {
       transformedModel = `${transformedModel}-low`;
     }
     
@@ -385,11 +403,12 @@ export function resolveModelWithVariant(
 
   if (isGemini3) {
     const level = budgetToGemini3Level(budget);
-    const isAntigravityGemini3Pro = base.quotaPreference === "antigravity" &&
-      isGemini3ProModel(base.actualModel);
+    const isAntigravityGemini3BasePro = base.quotaPreference === "antigravity" &&
+      isGemini3BaseProModel(base.actualModel);
 
     let actualModel = base.actualModel;
-    if (isAntigravityGemini3Pro) {
+    if (isAntigravityGemini3BasePro) {
+      // Only gemini-3-pro (3.0) uses tier suffix in model name
       const baseModel = base.actualModel.replace(/-(low|medium|high)$/, "");
       actualModel = `${baseModel}-${level}`;
     }


### PR DESCRIPTION
## Summary

Fixes #510 — `antigravity-gemini-3.1-pro` returns 404 "Requested entity was not found" for all users.

## Root Cause

The model resolver appended `-low` tier suffix to `gemini-3.1-pro`, producing `gemini-3.1-pro-low` — a model name the Antigravity API doesn't recognize. Only `gemini-3-pro` (3.0) supports tier suffixes in the model name. `gemini-3.1-pro` uses the bare model name + `thinkingLevel` parameter (same pattern as Flash models).

**Bug chain:**
1. User requests `antigravity-gemini-3.1-pro`
2. `resolveModelWithTier()` strips `antigravity-` prefix → `gemini-3.1-pro`
3. `isGemini3ProModel()` returns `true` (regex matches both 3.0 and 3.1)
4. `skipAlias = true` → appends `-low` → `gemini-3.1-pro-low`
5. API returns 404

## Changes

- Added `isGemini3BaseProModel()` helper to distinguish `gemini-3-pro` (supports tier suffix in model name) from `gemini-3.1+-pro` (bare name + thinkingLevel)
- Fixed `resolveModelWithTier()` — no longer appends `-low` for 3.1+ Pro models
- Fixed `resolveModelForHeaderStyle()` — antigravity path no longer appends `-low` for 3.1+ Pro
- Fixed `resolveModelWithVariant()` — no longer re-appends tier suffix for 3.1+ Pro
- Updated tests with corrected assertions across `model-resolver.test.ts` and `request.test.ts`
- Added regression tests confirming 3.0 Pro behavior unchanged (`gemini-3-pro-low/high` still works)

## Testing

- **920/920 tests pass** (0 failures, 25 pre-existing skipped)
- `npm run typecheck` ✅
- `npm run build` ✅
- New test cases verify 3.1 Pro bare name resolution across all 3 resolver functions
- Regression tests confirm 3.0 Pro behavior is unchanged

## Model Resolution Before/After

| Input | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| `antigravity-gemini-3.1-pro` | `gemini-3.1-pro-low` ❌ 404 | `gemini-3.1-pro` ✅ |
| `antigravity-gemini-3.1-pro-high` | `gemini-3.1-pro-high` ❌ 404 | `gemini-3.1-pro` ✅ (thinkingLevel=high) |
| `antigravity-gemini-3-pro` | `gemini-3-pro-low` ✅ | `gemini-3-pro-low` ✅ (unchanged) |
| `antigravity-gemini-3-pro-high` | `gemini-3-pro-high` ✅ | `gemini-3-pro-high` ✅ (unchanged) |

## Files Changed

- `src/plugin/transform/model-resolver.ts` — Core fix (3 code paths + new helper)
- `src/plugin/transform/model-resolver.test.ts` — Fixed assertions + 7 new test cases
- `src/plugin/request.test.ts` — Fixed 2 stale assertions