### PR TITLE
fix: stop manual projectId drift during account persistence

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -313,14 +313,17 @@ async function persistAccountPool(
     }
 
     // Update existing account (this handles both email match and token match cases)
-    // When email matches but token differs, this effectively replaces the old token
+    // When email matches but token differs, this effectively replaces the old token.
+    // Existing (disk) projectId/managedProjectId take priority over incoming
+    // (OAuth-fetched) values to prevent auto-detected fallbacks from overwriting
+    // manually configured project IDs.
     const oldToken = existing.refreshToken;
     accounts[existingIndex] = {
       ...existing,
       email: result.email ?? existing.email,
       refreshToken: parts.refreshToken,
-      projectId: parts.projectId ?? existing.projectId,
-      managedProjectId: parts.managedProjectId ?? existing.managedProjectId,
+      projectId: existing.projectId ?? parts.projectId,
+      managedProjectId: existing.managedProjectId ?? parts.managedProjectId,
       lastUsed: now,
     };
     

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -462,11 +462,14 @@ export class AccountManager {
 
   updateFromAuth(account: ManagedAccount, auth: OAuthAuthDetails): void {
     const parts = parseRefreshParts(auth.refresh);
-    // Preserve existing projectId/managedProjectId if not in the new parts
+    // Preserve existing (disk-loaded) projectId/managedProjectId over runtime values.
+    // The account's existing values may have been manually configured by the user;
+    // the auth refresh string may contain an auto-detected fallback that should not
+    // overwrite those manual edits.
     account.parts = {
       ...parts,
-      projectId: parts.projectId ?? account.parts.projectId,
-      managedProjectId: parts.managedProjectId ?? account.parts.managedProjectId,
+      projectId: account.parts.projectId ?? parts.projectId,
+      managedProjectId: account.parts.managedProjectId ?? parts.managedProjectId,
     };
     account.access = auth.access;
     account.expires = auth.expires;

--- a/src/plugin/storage.ts
+++ b/src/plugin/storage.ts
@@ -151,9 +151,11 @@ function mergeAccountStorage(existing: AccountStorageV3, incoming: AccountStorag
         accountMap.set(acc.refreshToken, {
           ...existingAcc,
           ...acc,
-          // Preserve manually configured projectId/managedProjectId if not in incoming
-          projectId: acc.projectId ?? existingAcc.projectId,
-          managedProjectId: acc.managedProjectId ?? existingAcc.managedProjectId,
+          // Preserve manually configured projectId/managedProjectId from disk.
+          // Existing (disk) values take priority over incoming (in-memory) values
+          // to prevent auto-detected fallback IDs from overwriting user edits.
+          projectId: existingAcc.projectId ?? acc.projectId,
+          managedProjectId: existingAcc.managedProjectId ?? acc.managedProjectId,
           rateLimitResetTimes: {
             ...existingAcc.rateLimitResetTimes,
             ...acc.rateLimitResetTimes,


### PR DESCRIPTION
## Summary
- preserve existing persisted `projectId` and `managedProjectId` values when merging account updates, so runtime/OAuth fallback values do not overwrite manual IDs
- apply the same precedence in `persistAccountPool` and `updateFromAuth` to keep project IDs stable across login, token refresh, and rotation saves
- regressions verified with full test/build run (`npm run build`, `npm test`)

## Why
Manual project IDs in `antigravity-accounts.json` could be overwritten by auto-detected fallback values during normal runtime saves, causing permission errors for Gemini/Antigravity requests.