### PR TITLE
fix(rotation): use toBeCloseTo for time-dependent token assertion

### DIFF
--- a/src/plugin/rotation.test.ts
+++ b/src/plugin/rotation.test.ts
@@ -273,7 +273,7 @@ describe("TokenBucketTracker", () => {
       tracker.consume(0, 10);
       tracker.consume(0, 10);
       tracker.consume(0, 10);
-      expect(tracker.getTokens(0)).toBe(20);
+      expect(tracker.getTokens(0)).toBeCloseTo(20, 2);
     });
   });
 


### PR DESCRIPTION
getTokens() applies sub-millisecond regeneration between consume calls, causing exact equality to flake. Aligns with other time-dependent assertions in the same file.