### PR TITLE
fix(cli): prevent TUI menu from overwriting quota/verify output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.3.3-beta.2",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-antigravity-auth",
-            "version": "1.3.3-beta.2",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@openauthjs/openauth": "^0.4.3",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,7 +11,7 @@ import {
 import { authorizeAntigravity, exchangeAntigravity } from "./antigravity/oauth";
 import type { AntigravityTokenExchangeResult } from "./antigravity/oauth";
 import { accessTokenExpired, isOAuthAuth, parseRefreshParts, formatRefreshParts } from "./plugin/auth";
-import { promptAddAnotherAccount, promptLoginMode, promptProjectId } from "./plugin/cli";
+import { promptAddAnotherAccount, promptLoginMode, promptProjectId, promptContinue } from "./plugin/cli";
 import { ensureProjectContext } from "./plugin/project";
 import {
   startAntigravityDebugRequest, 
@@ -2692,6 +2692,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                     await saveAccounts(existingStorage);
                   }
                   console.log("");
+                  await promptContinue();
                   continue;
                 }
 
@@ -2703,6 +2704,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                       await saveAccounts(existingStorage);
                       activeAccountManager?.setAccountEnabled(menuResult.toggleAccountIndex, acc.enabled);
                       console.log(`\nAccount ${acc.email || menuResult.toggleAccountIndex + 1} ${acc.enabled ? 'enabled' : 'disabled'}.\n`);
+                      await promptContinue();
                     }
                   }
                   continue;
@@ -2714,6 +2716,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                   if (verifyAll) {
                     if (existingStorage.accounts.length === 0) {
                       console.log("\nNo accounts available to verify.\n");
+                      await promptContinue();
                       continue;
                     }
 
@@ -2793,6 +2796,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                       console.log("");
                     }
 
+                    await promptContinue();
                     continue;
                   }
 
@@ -2803,12 +2807,14 @@ export const createAntigravityPlugin = (providerId: string) => async (
 
                   if (verifyAccountIndex === undefined) {
                     console.log("\nVerification cancelled.\n");
+                    await promptContinue();
                     continue;
                   }
 
                   const account = existingStorage.accounts[verifyAccountIndex];
                   if (!account) {
                     console.log(`\nAccount ${verifyAccountIndex + 1} not found.\n`);
+                    await promptContinue();
                     continue;
                   }
 
@@ -2829,6 +2835,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
                     } else {
                       console.log(`✓ ${label} is ready for requests.\n`);
                     }
+                    await promptContinue();
                     continue;
                   }
 
@@ -2866,10 +2873,12 @@ export const createAntigravityPlugin = (providerId: string) => async (
                     } else {
                       console.log("No verification URL was returned. Try re-authenticating this account.\n");
                     }
+                    await promptContinue();
                     continue;
                   }
 
                   console.log(`✗ ${label}: ${verification.message}\n`);
+                  await promptContinue();
                   continue;
                 }
 

--- a/src/plugin/cli.ts
+++ b/src/plugin/cli.ts
@@ -31,6 +31,7 @@ export async function promptAddAnotherAccount(currentCount: number): Promise<boo
 }
 
 export async function promptContinue(): Promise<void> {
+  if (!isTTY()) return;
   const rl = createInterface({ input, output });
   try {
     await rl.question("Press Enter to return to menu...");

--- a/src/plugin/cli.ts
+++ b/src/plugin/cli.ts
@@ -30,6 +30,15 @@ export async function promptAddAnotherAccount(currentCount: number): Promise<boo
   }
 }
 
+export async function promptContinue(): Promise<void> {
+  const rl = createInterface({ input, output });
+  try {
+    await rl.question("Press Enter to return to menu...");
+  } finally {
+    rl.close();
+  }
+}
+
 export type LoginMode = "add" | "fresh" | "manage" | "check" | "verify" | "verify-all" | "cancel";
 
 export interface ExistingAccountInfo {
@@ -149,6 +158,7 @@ export async function promptLoginMode(existingAccounts: ExistingAccountInfo[]): 
         } else {
           console.log(`\n✗ Failed to configure models: ${result.error}\n`);
         }
+        await promptContinue();
         continue;
       }
 


### PR DESCRIPTION
## Summary
Resolves #537.

When executing `opencode auth login` and selecting **Check quotas**, **Verify one account**, or **Verify all accounts**, the output is printed to the console but immediately overwritten by the TUI menu. This makes the information impossible to read as it flashes briefly before the menu reappears.

This PR adds a `promptContinue` helper that pauses execution and waits for the user to press Enter before returning to the main TUI menu, allowing the output to be read.

## Changes
- Added `promptContinue` in `src/plugin/cli.ts`.
- Added calls to `await promptContinue()` in `src/plugin.ts` and `src/plugin/cli.ts` after printing informative data (quotas, verification statuses, model configuration).