### PR TITLE
fix(build): preserve ESM imports in published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.3.3-beta.2",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-antigravity-auth",
-            "version": "1.3.3-beta.2",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "LICENSE"
     ],
     "scripts": {
-        "build": "tsc -p tsconfig.build.json",
+        "build": "tsc -p tsconfig.build.json && node script/fix-esm-imports.mjs",
         "build:schema": "npx tsx script/build-schema.ts",
         "typecheck": "tsc --noEmit",
         "test": "vitest run",

--- a/script/fix-esm-imports.mjs
+++ b/script/fix-esm-imports.mjs
@@ -1,0 +1,76 @@
+import { existsSync } from "node:fs"
+import { readdir, readFile, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const distDir = path.join(repoRoot, "dist")
+
+const importPatterns = [
+  /(from\s*["'])(\.{1,2}\/[^"']+)(["'])/g,
+  /(import\s*\(\s*["'])(\.{1,2}\/[^"']+)(["'])/g,
+  /(\bimport\s*["'])(\.{1,2}\/[^"']+)(["'])/g,
+]
+
+function hasExtension(specifier) {
+  return path.posix.extname(specifier) !== ""
+}
+
+function resolveSpecifier(filePath, specifier) {
+  if (hasExtension(specifier)) return specifier
+
+  const targetPath = path.resolve(path.dirname(filePath), specifier)
+  if (existsSync(`${targetPath}.js`)) return `${specifier}.js`
+  if (existsSync(path.join(targetPath, "index.js"))) return `${specifier}/index.js`
+  return specifier
+}
+
+async function listJsFiles(dir) {
+  const entries = await readdir(dir)
+  const files = []
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry)
+    const entryStat = await stat(entryPath)
+    if (entryStat.isDirectory()) {
+      files.push(...await listJsFiles(entryPath))
+    } else if (entry.endsWith(".js")) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}
+
+async function fixFile(filePath) {
+  const source = await readFile(filePath, "utf8")
+  let output = source
+
+  for (const pattern of importPatterns) {
+    output = output.replace(pattern, (match, prefix, specifier, suffix) => {
+      return `${prefix}${resolveSpecifier(filePath, specifier)}${suffix}`
+    })
+  }
+
+  if (output !== source) {
+    await writeFile(filePath, output)
+    return true
+  }
+
+  return false
+}
+
+async function main() {
+  if (!existsSync(distDir)) return
+
+  const files = await listJsFiles(distDir)
+  let changed = 0
+
+  for (const file of files) {
+    if (await fixFile(file)) changed += 1
+  }
+
+  console.log(`Fixed ESM import specifiers in ${changed} dist file(s)`)
+}
+
+await main()

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import { exec } from "node:child_process";
-import { tool } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin/tool";
 import {
   ANTIGRAVITY_DEFAULT_PROJECT_ID,
   ANTIGRAVITY_ENDPOINT_FALLBACKS,

--- a/src/plugin/quota-fallback.test.ts
+++ b/src/plugin/quota-fallback.test.ts
@@ -29,7 +29,7 @@ let getHeaderStyleFromUrl: GetHeaderStyleFromUrl | undefined;
 let resolveHeaderRoutingDecision: ResolveHeaderRoutingDecision | undefined;
 
 beforeAll(async () => {
-  vi.mock("@opencode-ai/plugin", () => ({
+  vi.mock("@opencode-ai/plugin/tool", () => ({
     tool: vi.fn(),
   }));
 


### PR DESCRIPTION
## Summary

Fixes #564.

The published package could fail to load in OpenCode because emitted relative ESM specifiers in `dist/**/*.js` omitted explicit file extensions. When the plugin failed to load, OpenCode fell back to the default Google provider and surfaced a misleading `GOOGLE_GENERATIVE_AI_API_KEY` error instead of using the Antigravity OAuth path.

## Changes

- add a post-build script that rewrites emitted relative ESM specifiers in `dist/**/*.js` to explicit `.js` or `/index.js` targets
- run that script from the `build` command after TypeScript compilation
- import `tool` from `@opencode-ai/plugin/tool` instead of the package root to avoid a dependency root-entry resolution failure
- update the related quota fallback test mock to use the same explicit subpath import

## Validation

- `npm run build`
- `npm run typecheck`
- `npm test`
- verified direct `import('./dist/index.js')`
- verified `npm pack` output by installing the tarball into a clean temporary project and importing `opencode-antigravity-auth`