### PR TITLE
Add Gemini 3.5 (Flash + Pro) and 3.1 Flash; bare CLI names for 3.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 ### Added
 
-- **Gemini 3.5 models** - Added `gemini-3.5-pro` and `gemini-3.5-flash` across both quota pools: Antigravity (`antigravity-gemini-3.5-pro`, `antigravity-gemini-3.5-flash`) and Gemini CLI (bare `gemini-3.5-pro`, `gemini-3.5-flash`). Pro exposes `low`/`high` thinking levels; Flash exposes `minimal`/`low`/`medium`/`high`. Rollout-dependent.
-- **Gemini 3.1 Flash** - Added `antigravity-gemini-3.1-flash` and Gemini CLI `gemini-3.1-flash` (confirmed present in the antigravity `agy` and `gemini` CLIs).
+- **Gemini 3.5 Flash** - Added `gemini-3.5-flash` across both quota pools: Antigravity (`antigravity-gemini-3.5-flash`) and Gemini CLI (bare `gemini-3.5-flash`). Flash exposes `minimal`/`low`/`medium`/`high` thinking levels. Rollout-dependent.
 
 ### Changed
 
-- **Bare Gemini CLI names for 3.1+** - Dotted-minor generations now use bare model names on the Gemini CLI backend (e.g. `gemini-3.1-pro`, `gemini-3.5-pro`, `gemini-3.5-flash`) instead of the legacy `-preview` suffix, matching the `agy`/`gemini` CLIs. Renamed the `gemini-3.1-pro-preview` entry to `gemini-3.1-pro`. The 3.0 line (`gemini-3-pro-preview`, `gemini-3-flash-preview`) and the legacy `gemini-3.1-pro-preview-customtools` entry are unchanged, and previously-configured model strings still route via the resolver.
+- **Bare Gemini CLI names for 3.1+** - Dotted-minor generations now use bare model names on the Gemini CLI backend (e.g. `gemini-3.1-pro`, `gemini-3.5-flash`) instead of the legacy `-preview` suffix, matching the `agy`/`gemini` CLIs. Renamed the `gemini-3.1-pro-preview` entry to `gemini-3.1-pro`. The 3.0 line (`gemini-3-pro-preview`, `gemini-3-flash-preview`) and the legacy `gemini-3.1-pro-preview-customtools` entry are unchanged, and previously-configured model strings still route via the resolver.
 
 ## [1.6.0] - 2026-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Gemini 3.5 models** - Added `gemini-3.5-pro` and `gemini-3.5-flash` across both quota pools: Antigravity (`antigravity-gemini-3.5-pro`, `antigravity-gemini-3.5-flash`) and Gemini CLI (bare `gemini-3.5-pro`, `gemini-3.5-flash`). Pro exposes `low`/`high` thinking levels; Flash exposes `minimal`/`low`/`medium`/`high`. Rollout-dependent.
+- **Gemini 3.1 Flash** - Added `antigravity-gemini-3.1-flash` and Gemini CLI `gemini-3.1-flash` (confirmed present in the antigravity `agy` and `gemini` CLIs).
+
+### Changed
+
+- **Bare Gemini CLI names for 3.1+** - Dotted-minor generations now use bare model names on the Gemini CLI backend (e.g. `gemini-3.1-pro`, `gemini-3.5-pro`, `gemini-3.5-flash`) instead of the legacy `-preview` suffix, matching the `agy`/`gemini` CLIs. Renamed the `gemini-3.1-pro-preview` entry to `gemini-3.1-pro`. The 3.0 line (`gemini-3-pro-preview`, `gemini-3-flash-preview`) and the legacy `gemini-3.1-pro-preview-customtools` entry are unchanged, and previously-configured model strings still route via the resolver.
+
 ## [1.6.0] - 2026-02-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ opencode run "Hello" --model=google/antigravity-claude-opus-4-6-thinking --varia
 |-------|----------|-------|
 | `antigravity-gemini-3-pro` | low, high | Gemini 3 Pro with thinking |
 | `antigravity-gemini-3.1-pro` | low, high | Gemini 3.1 Pro with thinking (rollout-dependent) |
-| `antigravity-gemini-3.5-pro` | low, high | Gemini 3.5 Pro with thinking (rollout-dependent) |
 | `antigravity-gemini-3-flash` | minimal, low, medium, high | Gemini 3 Flash with thinking |
-| `antigravity-gemini-3.1-flash` | minimal, low, medium, high | Gemini 3.1 Flash with thinking |
 | `antigravity-gemini-3.5-flash` | minimal, low, medium, high | Gemini 3.5 Flash with thinking (rollout-dependent) |
 | `antigravity-claude-sonnet-4-6` | — | Claude Sonnet 4.6 |
 | `antigravity-claude-opus-4-6-thinking` | low, max | Claude Opus 4.6 with extended thinking |
@@ -128,12 +126,10 @@ opencode run "Hello" --model=google/antigravity-claude-opus-4-6-thinking --varia
 | `gemini-2.5-flash` | Gemini 2.5 Flash |
 | `gemini-2.5-pro` | Gemini 2.5 Pro |
 | `gemini-3-flash-preview` | Gemini 3 Flash (preview) |
-| `gemini-3.1-flash` | Gemini 3.1 Flash |
 | `gemini-3.5-flash` | Gemini 3.5 Flash (rollout-dependent) |
 | `gemini-3-pro-preview` | Gemini 3 Pro (preview) |
 | `gemini-3.1-pro` | Gemini 3.1 Pro |
 | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools |
-| `gemini-3.5-pro` | Gemini 3.5 Pro (rollout-dependent) |
 
 > **Routing Behavior:**
 > - **Antigravity-first (default):** Gemini models use Antigravity quota across accounts.
@@ -179,28 +175,8 @@ Add this to your `~/.config/opencode/opencode.json`:
             "high": { "thinkingLevel": "high" }
           }
         },
-        "antigravity-gemini-3.5-pro": {
-          "name": "Gemini 3.5 Pro (Antigravity)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "low": { "thinkingLevel": "low" },
-            "high": { "thinkingLevel": "high" }
-          }
-        },
         "antigravity-gemini-3-flash": {
           "name": "Gemini 3 Flash (Antigravity)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-          "variants": {
-            "minimal": { "thinkingLevel": "minimal" },
-            "low": { "thinkingLevel": "low" },
-            "medium": { "thinkingLevel": "medium" },
-            "high": { "thinkingLevel": "high" }
-          }
-        },
-        "antigravity-gemini-3.1-flash": {
-          "name": "Gemini 3.1 Flash (Antigravity)",
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
@@ -250,11 +226,6 @@ Add this to your `~/.config/opencode/opencode.json`:
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
-        "gemini-3.1-flash": {
-          "name": "Gemini 3.1 Flash (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
         "gemini-3.5-flash": {
           "name": "Gemini 3.5 Flash (Gemini CLI)",
           "limit": { "context": 1048576, "output": 65536 },
@@ -272,11 +243,6 @@ Add this to your `~/.config/opencode/opencode.json`:
         },
         "gemini-3.1-pro-preview-customtools": {
           "name": "Gemini 3.1 Pro Preview Custom Tools (Gemini CLI)",
-          "limit": { "context": 1048576, "output": 65535 },
-          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
-        },
-        "gemini-3.5-pro": {
-          "name": "Gemini 3.5 Pro (Gemini CLI)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ opencode run "Hello" --model=google/antigravity-claude-opus-4-6-thinking --varia
 |-------|----------|-------|
 | `antigravity-gemini-3-pro` | low, high | Gemini 3 Pro with thinking |
 | `antigravity-gemini-3.1-pro` | low, high | Gemini 3.1 Pro with thinking (rollout-dependent) |
+| `antigravity-gemini-3.5-pro` | low, high | Gemini 3.5 Pro with thinking (rollout-dependent) |
 | `antigravity-gemini-3-flash` | minimal, low, medium, high | Gemini 3 Flash with thinking |
+| `antigravity-gemini-3.1-flash` | minimal, low, medium, high | Gemini 3.1 Flash with thinking |
+| `antigravity-gemini-3.5-flash` | minimal, low, medium, high | Gemini 3.5 Flash with thinking (rollout-dependent) |
 | `antigravity-claude-sonnet-4-6` | — | Claude Sonnet 4.6 |
 | `antigravity-claude-opus-4-6-thinking` | low, max | Claude Opus 4.6 with extended thinking |
 
@@ -125,9 +128,12 @@ opencode run "Hello" --model=google/antigravity-claude-opus-4-6-thinking --varia
 | `gemini-2.5-flash` | Gemini 2.5 Flash |
 | `gemini-2.5-pro` | Gemini 2.5 Pro |
 | `gemini-3-flash-preview` | Gemini 3 Flash (preview) |
+| `gemini-3.1-flash` | Gemini 3.1 Flash |
+| `gemini-3.5-flash` | Gemini 3.5 Flash (rollout-dependent) |
 | `gemini-3-pro-preview` | Gemini 3 Pro (preview) |
-| `gemini-3.1-pro-preview` | Gemini 3.1 Pro (preview, rollout-dependent) |
-| `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools (preview, rollout-dependent) |
+| `gemini-3.1-pro` | Gemini 3.1 Pro |
+| `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools |
+| `gemini-3.5-pro` | Gemini 3.5 Pro (rollout-dependent) |
 
 > **Routing Behavior:**
 > - **Antigravity-first (default):** Gemini models use Antigravity quota across accounts.
@@ -173,8 +179,39 @@ Add this to your `~/.config/opencode/opencode.json`:
             "high": { "thinkingLevel": "high" }
           }
         },
+        "antigravity-gemini-3.5-pro": {
+          "name": "Gemini 3.5 Pro (Antigravity)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingLevel": "low" },
+            "high": { "thinkingLevel": "high" }
+          }
+        },
         "antigravity-gemini-3-flash": {
           "name": "Gemini 3 Flash (Antigravity)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "minimal": { "thinkingLevel": "minimal" },
+            "low": { "thinkingLevel": "low" },
+            "medium": { "thinkingLevel": "medium" },
+            "high": { "thinkingLevel": "high" }
+          }
+        },
+        "antigravity-gemini-3.1-flash": {
+          "name": "Gemini 3.1 Flash (Antigravity)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "minimal": { "thinkingLevel": "minimal" },
+            "low": { "thinkingLevel": "low" },
+            "medium": { "thinkingLevel": "medium" },
+            "high": { "thinkingLevel": "high" }
+          }
+        },
+        "antigravity-gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash (Antigravity)",
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
@@ -213,18 +250,33 @@ Add this to your `~/.config/opencode/opencode.json`:
           "limit": { "context": 1048576, "output": 65536 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
+        "gemini-3.1-flash": {
+          "name": "Gemini 3.1 Flash (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
         "gemini-3-pro-preview": {
           "name": "Gemini 3 Pro Preview (Gemini CLI)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
-        "gemini-3.1-pro-preview": {
-          "name": "Gemini 3.1 Pro Preview (Gemini CLI)",
+        "gemini-3.1-pro": {
+          "name": "Gemini 3.1 Pro (Gemini CLI)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "gemini-3.1-pro-preview-customtools": {
           "name": "Gemini 3.1 Pro Preview Custom Tools (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "gemini-3.5-pro": {
+          "name": "Gemini 3.5 Pro (Gemini CLI)",
           "limit": { "context": 1048576, "output": 65535 },
           "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-antigravity-auth",
-    "version": "1.3.3-beta.2",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-antigravity-auth",
-            "version": "1.3.3-beta.2",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "@openauthjs/openauth": "^0.4.3",

--- a/src/plugin/config/models.test.ts
+++ b/src/plugin/config/models.test.ts
@@ -19,19 +19,15 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       "antigravity-claude-sonnet-4-6",
       "antigravity-gemini-3-flash",
       "antigravity-gemini-3-pro",
-      "antigravity-gemini-3.1-flash",
       "antigravity-gemini-3.1-pro",
       "antigravity-gemini-3.5-flash",
-      "antigravity-gemini-3.5-pro",
       "gemini-2.5-flash",
       "gemini-2.5-pro",
       "gemini-3-flash-preview",
       "gemini-3-pro-preview",
-      "gemini-3.1-flash",
       "gemini-3.1-pro",
       "gemini-3.1-pro-preview-customtools",
       "gemini-3.5-flash",
-      "gemini-3.5-pro",
     ]);
   });
 
@@ -50,18 +46,6 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       minimal: { thinkingLevel: "minimal" },
       low: { thinkingLevel: "low" },
       medium: { thinkingLevel: "medium" },
-      high: { thinkingLevel: "high" },
-    });
-
-    expect(getModel("antigravity-gemini-3.1-flash").variants).toEqual({
-      minimal: { thinkingLevel: "minimal" },
-      low: { thinkingLevel: "low" },
-      medium: { thinkingLevel: "medium" },
-      high: { thinkingLevel: "high" },
-    });
-
-    expect(getModel("antigravity-gemini-3.5-pro").variants).toEqual({
-      low: { thinkingLevel: "low" },
       high: { thinkingLevel: "high" },
     });
 

--- a/src/plugin/config/models.test.ts
+++ b/src/plugin/config/models.test.ts
@@ -19,13 +19,19 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       "antigravity-claude-sonnet-4-6",
       "antigravity-gemini-3-flash",
       "antigravity-gemini-3-pro",
+      "antigravity-gemini-3.1-flash",
       "antigravity-gemini-3.1-pro",
+      "antigravity-gemini-3.5-flash",
+      "antigravity-gemini-3.5-pro",
       "gemini-2.5-flash",
       "gemini-2.5-pro",
       "gemini-3-flash-preview",
       "gemini-3-pro-preview",
-      "gemini-3.1-pro-preview",
+      "gemini-3.1-flash",
+      "gemini-3.1-pro",
       "gemini-3.1-pro-preview-customtools",
+      "gemini-3.5-flash",
+      "gemini-3.5-pro",
     ]);
   });
 
@@ -41,6 +47,25 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
     });
 
     expect(getModel("antigravity-gemini-3-flash").variants).toEqual({
+      minimal: { thinkingLevel: "minimal" },
+      low: { thinkingLevel: "low" },
+      medium: { thinkingLevel: "medium" },
+      high: { thinkingLevel: "high" },
+    });
+
+    expect(getModel("antigravity-gemini-3.1-flash").variants).toEqual({
+      minimal: { thinkingLevel: "minimal" },
+      low: { thinkingLevel: "low" },
+      medium: { thinkingLevel: "medium" },
+      high: { thinkingLevel: "high" },
+    });
+
+    expect(getModel("antigravity-gemini-3.5-pro").variants).toEqual({
+      low: { thinkingLevel: "low" },
+      high: { thinkingLevel: "high" },
+    });
+
+    expect(getModel("antigravity-gemini-3.5-flash").variants).toEqual({
       minimal: { thinkingLevel: "minimal" },
       low: { thinkingLevel: "low" },
       medium: { thinkingLevel: "medium" },

--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -56,28 +56,8 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
       high: { thinkingLevel: "high" },
     },
   },
-  "antigravity-gemini-3.5-pro": {
-    name: "Gemini 3.5 Pro (Antigravity)",
-    limit: { context: 1048576, output: 65535 },
-    modalities: DEFAULT_MODALITIES,
-    variants: {
-      low: { thinkingLevel: "low" },
-      high: { thinkingLevel: "high" },
-    },
-  },
   "antigravity-gemini-3-flash": {
     name: "Gemini 3 Flash (Antigravity)",
-    limit: { context: 1048576, output: 65536 },
-    modalities: DEFAULT_MODALITIES,
-    variants: {
-      minimal: { thinkingLevel: "minimal" },
-      low: { thinkingLevel: "low" },
-      medium: { thinkingLevel: "medium" },
-      high: { thinkingLevel: "high" },
-    },
-  },
-  "antigravity-gemini-3.1-flash": {
-    name: "Gemini 3.1 Flash (Antigravity)",
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
     variants: {
@@ -127,11 +107,6 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
   },
-  "gemini-3.1-flash": {
-    name: "Gemini 3.1 Flash (Gemini CLI)",
-    limit: { context: 1048576, output: 65536 },
-    modalities: DEFAULT_MODALITIES,
-  },
   "gemini-3.5-flash": {
     name: "Gemini 3.5 Flash (Gemini CLI)",
     limit: { context: 1048576, output: 65536 },
@@ -149,11 +124,6 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
   },
   "gemini-3.1-pro-preview-customtools": {
     name: "Gemini 3.1 Pro Preview Custom Tools (Gemini CLI)",
-    limit: { context: 1048576, output: 65535 },
-    modalities: DEFAULT_MODALITIES,
-  },
-  "gemini-3.5-pro": {
-    name: "Gemini 3.5 Pro (Gemini CLI)",
     limit: { context: 1048576, output: 65535 },
     modalities: DEFAULT_MODALITIES,
   },

--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -56,8 +56,39 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
       high: { thinkingLevel: "high" },
     },
   },
+  "antigravity-gemini-3.5-pro": {
+    name: "Gemini 3.5 Pro (Antigravity)",
+    limit: { context: 1048576, output: 65535 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      low: { thinkingLevel: "low" },
+      high: { thinkingLevel: "high" },
+    },
+  },
   "antigravity-gemini-3-flash": {
     name: "Gemini 3 Flash (Antigravity)",
+    limit: { context: 1048576, output: 65536 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      minimal: { thinkingLevel: "minimal" },
+      low: { thinkingLevel: "low" },
+      medium: { thinkingLevel: "medium" },
+      high: { thinkingLevel: "high" },
+    },
+  },
+  "antigravity-gemini-3.1-flash": {
+    name: "Gemini 3.1 Flash (Antigravity)",
+    limit: { context: 1048576, output: 65536 },
+    modalities: DEFAULT_MODALITIES,
+    variants: {
+      minimal: { thinkingLevel: "minimal" },
+      low: { thinkingLevel: "low" },
+      medium: { thinkingLevel: "medium" },
+      high: { thinkingLevel: "high" },
+    },
+  },
+  "antigravity-gemini-3.5-flash": {
+    name: "Gemini 3.5 Flash (Antigravity)",
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
     variants: {
@@ -96,18 +127,33 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
   },
+  "gemini-3.1-flash": {
+    name: "Gemini 3.1 Flash (Gemini CLI)",
+    limit: { context: 1048576, output: 65536 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "gemini-3.5-flash": {
+    name: "Gemini 3.5 Flash (Gemini CLI)",
+    limit: { context: 1048576, output: 65536 },
+    modalities: DEFAULT_MODALITIES,
+  },
   "gemini-3-pro-preview": {
     name: "Gemini 3 Pro Preview (Gemini CLI)",
     limit: { context: 1048576, output: 65535 },
     modalities: DEFAULT_MODALITIES,
   },
-  "gemini-3.1-pro-preview": {
-    name: "Gemini 3.1 Pro Preview (Gemini CLI)",
+  "gemini-3.1-pro": {
+    name: "Gemini 3.1 Pro (Gemini CLI)",
     limit: { context: 1048576, output: 65535 },
     modalities: DEFAULT_MODALITIES,
   },
   "gemini-3.1-pro-preview-customtools": {
     name: "Gemini 3.1 Pro Preview Custom Tools (Gemini CLI)",
+    limit: { context: 1048576, output: 65535 },
+    modalities: DEFAULT_MODALITIES,
+  },
+  "gemini-3.5-pro": {
+    name: "Gemini 3.5 Pro (Gemini CLI)",
     limit: { context: 1048576, output: 65535 },
     modalities: DEFAULT_MODALITIES,
   },

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1084,7 +1084,7 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.5-pro-low");
       });
 
-      it("keeps gemini-3.5-flash as gemini-3.5-flash for antigravity headerStyle", () => {
+      it("transforms gemini-3.5-flash to the Antigravity low backend id for antigravity headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1093,7 +1093,7 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
-        expect(result.effectiveModel).toBe("gemini-3.5-flash");
+        expect(result.effectiveModel).toBe("gemini-3.5-flash-low");
       });
 
       it("injects default thinkingLevel for bare gemini-3.5-flash on antigravity", () => {
@@ -1105,6 +1105,7 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
+        expect(result.effectiveModel).toBe("gemini-3.5-flash-low");
         const wrapped = JSON.parse(result.init.body as string);
         expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
           thinkingLevel: "low",
@@ -1127,6 +1128,7 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
+        expect(result.effectiveModel).toBe("gemini-3.5-flash-low");
         const wrapped = JSON.parse(result.init.body as string);
         expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
           thinkingLevel: "low",
@@ -1154,10 +1156,68 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
+        expect(result.effectiveModel).toBe("gemini-3.5-flash-low");
         const wrapped = JSON.parse(result.init.body as string);
         expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
           thinkingLevel: "medium",
           includeThoughts: false,
+        });
+      });
+
+      it("maps explicit high thinkingLevel for gemini-3.5-flash to the Antigravity high backend id", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              contents: [],
+              generationConfig: {
+                thinkingConfig: {
+                  thinkingLevel: "high",
+                  includeThoughts: true,
+                },
+              },
+            }),
+          },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        expect(result.effectiveModel).toBe("gemini-3-flash-agent");
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.model).toBe("gemini-3-flash-agent");
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "high",
+          includeThoughts: true,
+        });
+      });
+
+      it("maps providerOptions high variant for gemini-3.5-flash to the Antigravity high backend id", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              contents: [],
+              providerOptions: {
+                google: {
+                  thinkingLevel: "high",
+                },
+              },
+            }),
+          },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        expect(result.effectiveModel).toBe("gemini-3-flash-agent");
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.model).toBe("gemini-3-flash-agent");
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "high",
+          includeThoughts: true,
         });
       });
 

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1072,18 +1072,6 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
       });
 
-      it("transforms gemini-3.5-pro to gemini-3.5-pro-low for antigravity headerStyle", () => {
-        const result = prepareAntigravityRequest(
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-pro:generateContent",
-          { method: "POST", body: JSON.stringify({ contents: [] }) },
-          mockAccessToken,
-          mockProjectId,
-          undefined,
-          "antigravity"
-        );
-        expect(result.effectiveModel).toBe("gemini-3.5-pro-low");
-      });
-
       it("transforms gemini-3.5-flash to the Antigravity low backend id for antigravity headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
@@ -1269,18 +1257,6 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.1-pro");
       });
 
-      it("transforms gemini-3.5-pro-low to gemini-3.5-pro (bare) for gemini-cli headerStyle", () => {
-        const result = prepareAntigravityRequest(
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-pro-low:generateContent",
-          { method: "POST", body: JSON.stringify({ contents: [] }) },
-          mockAccessToken,
-          mockProjectId,
-          undefined,
-          "gemini-cli"
-        );
-        expect(result.effectiveModel).toBe("gemini-3.5-pro");
-      });
-
       it("keeps gemini-3.5-flash as gemini-3.5-flash (bare) for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
@@ -1307,18 +1283,6 @@ it("removes x-api-key header", () => {
           thinkingLevel: "low",
           includeThoughts: true,
         });
-      });
-
-      it("keeps gemini-3.1-flash as gemini-3.1-flash (bare) for gemini-cli headerStyle", () => {
-        const result = prepareAntigravityRequest(
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash:generateContent",
-          { method: "POST", body: JSON.stringify({ contents: [] }) },
-          mockAccessToken,
-          mockProjectId,
-          undefined,
-          "gemini-cli"
-        );
-        expect(result.effectiveModel).toBe("gemini-3.1-flash");
       });
 
       it("keeps gemini-3.1-pro-preview-customtools unchanged for gemini-cli headerStyle", () => {

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1072,6 +1072,30 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
       });
 
+      it("transforms gemini-3.5-pro to gemini-3.5-pro-low for antigravity headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-pro:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.5-pro-low");
+      });
+
+      it("keeps gemini-3.5-flash as gemini-3.5-flash for antigravity headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.5-flash");
+      });
+
       it("transforms gemini-3-flash to gemini-3-flash-preview for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent",
@@ -1096,7 +1120,7 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3-pro-preview");
       });
 
-      it("transforms gemini-3.1-pro-low to gemini-3.1-pro-preview for gemini-cli headerStyle", () => {
+      it("transforms gemini-3.1-pro-low to gemini-3.1-pro (bare) for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-low:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1105,7 +1129,43 @@ it("removes x-api-key header", () => {
           undefined,
           "gemini-cli"
         );
-        expect(result.effectiveModel).toBe("gemini-3.1-pro-preview");
+        expect(result.effectiveModel).toBe("gemini-3.1-pro");
+      });
+
+      it("transforms gemini-3.5-pro-low to gemini-3.5-pro (bare) for gemini-cli headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-pro-low:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.5-pro");
+      });
+
+      it("keeps gemini-3.5-flash as gemini-3.5-flash (bare) for gemini-cli headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.5-flash");
+      });
+
+      it("keeps gemini-3.1-flash as gemini-3.1-flash (bare) for gemini-cli headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.1-flash");
       });
 
       it("keeps gemini-3.1-pro-preview-customtools unchanged for gemini-cli headerStyle", () => {

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1096,6 +1096,71 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.5-flash");
       });
 
+      it("injects default thinkingLevel for bare gemini-3.5-flash on antigravity", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "low",
+          includeThoughts: true,
+        });
+      });
+
+      it("injects default thinkingLevel for wrapped gemini-3.5-flash requests", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              project: "existing-project",
+              request: { contents: [] },
+            }),
+          },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "low",
+          includeThoughts: true,
+        });
+      });
+
+      it("preserves explicit thinkingLevel for gemini-3.5-flash", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              contents: [],
+              generationConfig: {
+                thinkingConfig: {
+                  thinkingLevel: "medium",
+                  includeThoughts: false,
+                },
+              },
+            }),
+          },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "antigravity"
+        );
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "medium",
+          includeThoughts: false,
+        });
+      });
+
       it("transforms gemini-3-flash to gemini-3-flash-preview for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent",
@@ -1132,6 +1197,18 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3.1-pro");
       });
 
+      it("strips legacy gemini-3.1-pro-preview to bare name for gemini-cli headerStyle", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        expect(result.effectiveModel).toBe("gemini-3.1-pro");
+      });
+
       it("transforms gemini-3.5-pro-low to gemini-3.5-pro (bare) for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-pro-low:generateContent",
@@ -1154,6 +1231,22 @@ it("removes x-api-key header", () => {
           "gemini-cli"
         );
         expect(result.effectiveModel).toBe("gemini-3.5-flash");
+      });
+
+      it("injects default thinkingLevel for bare gemini-3.5-flash on gemini-cli", () => {
+        const result = prepareAntigravityRequest(
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+          { method: "POST", body: JSON.stringify({ contents: [] }) },
+          mockAccessToken,
+          mockProjectId,
+          undefined,
+          "gemini-cli"
+        );
+        const wrapped = JSON.parse(result.init.body as string);
+        expect(wrapped.request.generationConfig.thinkingConfig).toMatchObject({
+          thinkingLevel: "low",
+          includeThoughts: true,
+        });
       });
 
       it("keeps gemini-3.1-flash as gemini-3.1-flash (bare) for gemini-cli headerStyle", () => {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -63,6 +63,7 @@ import {
   resolveModelWithTier,
   resolveModelWithVariant,
   resolveModelForHeaderStyle,
+  resolveAntigravityGemini35FlashBackendModel,
   isClaudeModel,
   isClaudeThinkingModel,
   CLAUDE_THINKING_MAX_OUTPUT_TOKENS,
@@ -884,6 +885,37 @@ export function prepareAntigravityRequest(
           }
         }
 
+        if (effectiveModel.toLowerCase().includes("gemini-3")) {
+          for (const req of requestObjects) {
+            const variantConfig = extractVariantThinkingConfig(
+              (req as any).providerOptions as Record<string, unknown> | undefined,
+              (req as any).generationConfig as Record<string, unknown> | undefined,
+            );
+            if (variantConfig?.thinkingLevel) {
+              tierThinkingLevel = variantConfig.thinkingLevel;
+              tierThinkingBudget = undefined;
+              break;
+            }
+            if (typeof variantConfig?.thinkingBudget === "number") {
+              tierThinkingLevel = variantConfig.thinkingBudget <= 8192 ? "low"
+                : variantConfig.thinkingBudget <= 16384 ? "medium" : "high";
+              tierThinkingBudget = undefined;
+              break;
+            }
+          }
+        }
+
+        if (headerStyle === "antigravity") {
+          const gemini35FlashBackendModel = resolveAntigravityGemini35FlashBackendModel(
+            rawModel,
+            tierThinkingLevel,
+          );
+          if (gemini35FlashBackendModel) {
+            effectiveModel = gemini35FlashBackendModel;
+            wrappedBody.model = gemini35FlashBackendModel;
+          }
+        }
+
         const conversationKey = resolveConversationKeyFromRequests(requestObjects);
         // Strip tier suffix from model for cache key to prevent cache misses on tier change
         // e.g., "claude-opus-4-6-thinking-high" -> "claude-opus-4-6-thinking"
@@ -967,6 +999,16 @@ export function prepareAntigravityRequest(
             // Claude / Gemini 2.5 - use budget directly
             tierThinkingBudget = variantConfig.thinkingBudget;
             tierThinkingLevel = undefined;
+          }
+        }
+
+        if (headerStyle === "antigravity") {
+          const gemini35FlashBackendModel = resolveAntigravityGemini35FlashBackendModel(
+            rawModel,
+            tierThinkingLevel,
+          );
+          if (gemini35FlashBackendModel) {
+            effectiveModel = gemini35FlashBackendModel;
           }
         }
 

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -719,6 +719,35 @@ function generateSyntheticProjectId(): string {
   return `${adj}-${noun}-${randomPart}`;
 }
 
+function ensureDefaultGemini3ThinkingLevel(
+  requestPayload: Record<string, unknown>,
+  effectiveModel: string,
+  thinkingLevel?: string,
+): void {
+  if (!effectiveModel.toLowerCase().includes("gemini-3") || isImageGenerationModel(effectiveModel)) {
+    return;
+  }
+
+  const generationConfig =
+    requestPayload.generationConfig && typeof requestPayload.generationConfig === "object"
+      ? (requestPayload.generationConfig as Record<string, unknown>)
+      : {};
+  const thinkingConfig =
+    generationConfig.thinkingConfig && typeof generationConfig.thinkingConfig === "object"
+      ? (generationConfig.thinkingConfig as Record<string, unknown>)
+      : {};
+
+  if (typeof thinkingConfig.thinkingLevel !== "string") {
+    thinkingConfig.thinkingLevel = thinkingLevel ?? "low";
+  }
+  if (typeof thinkingConfig.includeThoughts !== "boolean") {
+    thinkingConfig.includeThoughts = true;
+  }
+
+  generationConfig.thinkingConfig = thinkingConfig;
+  requestPayload.generationConfig = generationConfig;
+}
+
 const STREAM_ACTION = "streamGenerateContent";
 
 /**
@@ -869,6 +898,7 @@ export function prepareAntigravityRequest(
           // Use stable session ID for signature caching across multi-turn conversations
           (req as any).sessionId = signatureSessionKey;
           stripInjectedDebugFromRequestPayload(req as Record<string, unknown>);
+          ensureDefaultGemini3ThinkingLevel(req as Record<string, unknown>, effectiveModel, tierThinkingLevel);
 
           if (isClaude) {
             // Step 0: Sanitize cross-model metadata (strips Gemini signatures when sending to Claude)

--- a/src/plugin/transform/index.ts
+++ b/src/plugin/transform/index.ts
@@ -22,6 +22,7 @@ export {
   resolveModelWithTier,
   resolveModelWithVariant,
   resolveModelForHeaderStyle,
+  resolveAntigravityGemini35FlashBackendModel,
   getModelFamily,
   MODEL_ALIASES,
   THINKING_TIER_BUDGETS,

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -144,10 +144,22 @@ describe("resolveModelWithTier", () => {
       expect(result.thinkingLevel).toBe("low");
     });
 
-    it("antigravity-gemini-3.5-flash gets default thinkingLevel 'low'", () => {
+    it("antigravity-gemini-3.5-flash maps to the Antigravity low backend id by default", () => {
       const result = resolveModelWithTier("antigravity-gemini-3.5-flash");
-      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.actualModel).toBe("gemini-3.5-flash-low");
       expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("antigravity-gemini-3.5-flash-high maps to the Antigravity high backend id", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.5-flash-high");
+      expect(result.actualModel).toBe("gemini-3-flash-agent");
+      expect(result.thinkingLevel).toBe("high");
+    });
+
+    it("antigravity-gemini-3.5-flash-medium uses the low backend id with medium thinkingLevel", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.5-flash-medium");
+      expect(result.actualModel).toBe("gemini-3.5-flash-low");
+      expect(result.thinkingLevel).toBe("medium");
     });
 
     it("antigravity-gemini-3.1-flash gets default thinkingLevel 'low'", () => {
@@ -330,9 +342,16 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("keeps gemini-3.5-flash as gemini-3.5-flash for antigravity", () => {
+    it("transforms gemini-3.5-flash to the Antigravity low backend id", () => {
       const result = resolveModelForHeaderStyle("gemini-3.5-flash", "antigravity");
-      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.actualModel).toBe("gemini-3.5-flash-low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("transforms gemini-3.5-flash-high to the Antigravity high backend id", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.5-flash-high", "antigravity");
+      expect(result.actualModel).toBe("gemini-3-flash-agent");
+      expect(result.thinkingLevel).toBe("high");
       expect(result.quotaPreference).toBe("antigravity");
     });
 

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -42,20 +42,6 @@ describe("resolveModelWithTier", () => {
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("gemini-3.1-flash (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
-      const result = resolveModelWithTier("gemini-3.1-flash");
-      expect(result.actualModel).toBe("gemini-3.1-flash");
-      expect(result.thinkingLevel).toBe("low");
-      expect(result.quotaPreference).toBe("antigravity");
-    });
-
-    it("gemini-3.5-pro (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
-      const result = resolveModelWithTier("gemini-3.5-pro");
-      expect(result.actualModel).toBe("gemini-3.5-pro");
-      expect(result.thinkingLevel).toBe("low");
-      expect(result.quotaPreference).toBe("antigravity");
-    });
-
     it("gemini-3.5-flash (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
       const result = resolveModelWithTier("gemini-3.5-flash");
       expect(result.actualModel).toBe("gemini-3.5-flash");
@@ -138,12 +124,6 @@ describe("resolveModelWithTier", () => {
       expect(result.thinkingLevel).toBe("low");
     });
 
-    it("antigravity-gemini-3.5-pro gets default -low model", () => {
-      const result = resolveModelWithTier("antigravity-gemini-3.5-pro");
-      expect(result.actualModel).toBe("gemini-3.5-pro-low");
-      expect(result.thinkingLevel).toBe("low");
-    });
-
     it("antigravity-gemini-3.5-flash maps to the Antigravity low backend id by default", () => {
       const result = resolveModelWithTier("antigravity-gemini-3.5-flash");
       expect(result.actualModel).toBe("gemini-3.5-flash-low");
@@ -160,12 +140,6 @@ describe("resolveModelWithTier", () => {
       const result = resolveModelWithTier("antigravity-gemini-3.5-flash-medium");
       expect(result.actualModel).toBe("gemini-3.5-flash-low");
       expect(result.thinkingLevel).toBe("medium");
-    });
-
-    it("antigravity-gemini-3.1-flash gets default thinkingLevel 'low'", () => {
-      const result = resolveModelWithTier("antigravity-gemini-3.1-flash");
-      expect(result.actualModel).toBe("gemini-3.1-flash");
-      expect(result.thinkingLevel).toBe("low");
     });
   });
 
@@ -336,12 +310,6 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("transforms gemini-3.5-pro to gemini-3.5-pro-low for antigravity", () => {
-      const result = resolveModelForHeaderStyle("gemini-3.5-pro", "antigravity");
-      expect(result.actualModel).toBe("gemini-3.5-pro-low");
-      expect(result.quotaPreference).toBe("antigravity");
-    });
-
     it("transforms gemini-3.5-flash to the Antigravity low backend id", () => {
       const result = resolveModelForHeaderStyle("gemini-3.5-flash", "antigravity");
       expect(result.actualModel).toBe("gemini-3.5-flash-low");
@@ -352,12 +320,6 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       const result = resolveModelForHeaderStyle("gemini-3.5-flash-high", "antigravity");
       expect(result.actualModel).toBe("gemini-3-flash-agent");
       expect(result.thinkingLevel).toBe("high");
-      expect(result.quotaPreference).toBe("antigravity");
-    });
-
-    it("keeps gemini-3.1-flash as gemini-3.1-flash for antigravity", () => {
-      const result = resolveModelForHeaderStyle("gemini-3.1-flash", "antigravity");
-      expect(result.actualModel).toBe("gemini-3.1-flash");
       expect(result.quotaPreference).toBe("antigravity");
     });
   });
@@ -399,21 +361,9 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
-    it("transforms gemini-3.5-pro-low to gemini-3.5-pro (bare) for gemini-cli", () => {
-      const result = resolveModelForHeaderStyle("gemini-3.5-pro-low", "gemini-cli");
-      expect(result.actualModel).toBe("gemini-3.5-pro");
-      expect(result.quotaPreference).toBe("gemini-cli");
-    });
-
     it("keeps gemini-3.5-flash as gemini-3.5-flash (bare) for gemini-cli", () => {
       const result = resolveModelForHeaderStyle("gemini-3.5-flash", "gemini-cli");
       expect(result.actualModel).toBe("gemini-3.5-flash");
-      expect(result.quotaPreference).toBe("gemini-cli");
-    });
-
-    it("keeps gemini-3.1-flash as gemini-3.1-flash (bare) for gemini-cli", () => {
-      const result = resolveModelForHeaderStyle("gemini-3.1-flash", "gemini-cli");
-      expect(result.actualModel).toBe("gemini-3.1-flash");
       expect(result.quotaPreference).toBe("gemini-cli");
     });
   });

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -41,6 +41,27 @@ describe("resolveModelWithTier", () => {
       expect(result.thinkingLevel).toBe("low");
       expect(result.quotaPreference).toBe("antigravity");
     });
+
+    it("gemini-3.1-flash (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
+      const result = resolveModelWithTier("gemini-3.1-flash");
+      expect(result.actualModel).toBe("gemini-3.1-flash");
+      expect(result.thinkingLevel).toBe("low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("gemini-3.5-pro (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
+      const result = resolveModelWithTier("gemini-3.5-pro");
+      expect(result.actualModel).toBe("gemini-3.5-pro");
+      expect(result.thinkingLevel).toBe("low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("gemini-3.5-flash (bare) gets default thinkingLevel 'low' with antigravity quota", () => {
+      const result = resolveModelWithTier("gemini-3.5-flash");
+      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.thinkingLevel).toBe("low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
   });
 
   describe("All Gemini models default to antigravity quota", () => {
@@ -114,6 +135,24 @@ describe("resolveModelWithTier", () => {
     it("antigravity-gemini-3.1-pro gets default -low model", () => {
       const result = resolveModelWithTier("antigravity-gemini-3.1-pro");
       expect(result.actualModel).toBe("gemini-3.1-pro-low");
+      expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("antigravity-gemini-3.5-pro gets default -low model", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.5-pro");
+      expect(result.actualModel).toBe("gemini-3.5-pro-low");
+      expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("antigravity-gemini-3.5-flash gets default thinkingLevel 'low'", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.5-flash");
+      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.thinkingLevel).toBe("low");
+    });
+
+    it("antigravity-gemini-3.1-flash gets default thinkingLevel 'low'", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3.1-flash");
+      expect(result.actualModel).toBe("gemini-3.1-flash");
       expect(result.thinkingLevel).toBe("low");
     });
   });
@@ -284,6 +323,24 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.actualModel).toBe("gemini-3.1-pro-low");
       expect(result.quotaPreference).toBe("antigravity");
     });
+
+    it("transforms gemini-3.5-pro to gemini-3.5-pro-low for antigravity", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.5-pro", "antigravity");
+      expect(result.actualModel).toBe("gemini-3.5-pro-low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("keeps gemini-3.5-flash as gemini-3.5-flash for antigravity", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.5-flash", "antigravity");
+      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("keeps gemini-3.1-flash as gemini-3.1-flash for antigravity", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.1-flash", "antigravity");
+      expect(result.actualModel).toBe("gemini-3.1-flash");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
   });
 
   describe("quota fallback from antigravity to gemini-cli", () => {
@@ -299,15 +356,33 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
-    it("transforms gemini-3.1-pro-low to gemini-3.1-pro-preview for gemini-cli", () => {
+    it("transforms gemini-3.1-pro-low to gemini-3.1-pro (bare) for gemini-cli", () => {
       const result = resolveModelForHeaderStyle("gemini-3.1-pro-low", "gemini-cli");
-      expect(result.actualModel).toBe("gemini-3.1-pro-preview");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
     it("keeps gemini-3.1-pro-preview-customtools unchanged for gemini-cli", () => {
       const result = resolveModelForHeaderStyle("gemini-3.1-pro-preview-customtools", "gemini-cli");
       expect(result.actualModel).toBe("gemini-3.1-pro-preview-customtools");
+      expect(result.quotaPreference).toBe("gemini-cli");
+    });
+
+    it("transforms gemini-3.5-pro-low to gemini-3.5-pro (bare) for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.5-pro-low", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.5-pro");
+      expect(result.quotaPreference).toBe("gemini-cli");
+    });
+
+    it("keeps gemini-3.5-flash as gemini-3.5-flash (bare) for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.5-flash", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.5-flash");
+      expect(result.quotaPreference).toBe("gemini-cli");
+    });
+
+    it("keeps gemini-3.1-flash as gemini-3.1-flash (bare) for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.1-flash", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.1-flash");
       expect(result.quotaPreference).toBe("gemini-cli");
     });
   });

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -362,9 +362,21 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
+    it("strips legacy preview suffix from gemini-3.1-pro for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.1-pro-preview", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
+      expect(result.quotaPreference).toBe("gemini-cli");
+    });
+
     it("keeps gemini-3.1-pro-preview-customtools unchanged for gemini-cli", () => {
       const result = resolveModelForHeaderStyle("gemini-3.1-pro-preview-customtools", "gemini-cli");
       expect(result.actualModel).toBe("gemini-3.1-pro-preview-customtools");
+      expect(result.quotaPreference).toBe("gemini-cli");
+    });
+
+    it("keeps dotted 3.0 models on legacy preview suffix for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3.0-pro-low", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.0-pro-preview");
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -75,7 +75,7 @@ const GEMINI_35_FLASH_HIGH_MODEL = "gemini-3-flash-agent";
  * Dotted-minor Gemini generations (gemini-3.1, gemini-3.5, ...) use BARE model
  * names on the Gemini CLI backend, unlike the legacy 3.0 line (gemini-3-pro) which
  * uses a "-preview" suffix. Confirmed against the antigravity (`agy`) and `gemini`
- * CLIs, which ship `gemini-3.1-pro`/`gemini-3.1-flash` (no `-preview`).
+ * CLIs, which ship `gemini-3.1-pro` (no `-preview`).
  */
 const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.(?:[1-9]\d*)/i;
 

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -63,6 +63,9 @@ const TIER_REGEX = /-(minimal|low|medium|high)$/;
 const QUOTA_PREFIX_REGEX = /^antigravity-/i;
 const GEMINI_3_PRO_REGEX = /^gemini-3(?:\.\d+)?-pro/i;
 const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
+const GEMINI_35_FLASH_REGEX = /^gemini-3\.5-flash(?:-(minimal|low|medium|high))?$/i;
+const GEMINI_35_FLASH_LOW_MODEL = "gemini-3.5-flash-low";
+const GEMINI_35_FLASH_HIGH_MODEL = "gemini-3-flash-agent";
 /**
  * Dotted-minor Gemini generations (gemini-3.1, gemini-3.5, ...) use BARE model
  * names on the Gemini CLI backend, unlike the legacy 3.0 line (gemini-3-pro) which
@@ -145,6 +148,24 @@ function isGemini3FlashModel(model: string): boolean {
 }
 
 /**
+ * Cloud Code does not expose a bare `gemini-3.5-flash` backend id.
+ * Antigravity/agy resolves the UI model to these advertised ids instead.
+ */
+export function resolveAntigravityGemini35FlashBackendModel(
+  model: string,
+  thinkingLevel?: string,
+): string | undefined {
+  const modelWithoutQuota = model.replace(QUOTA_PREFIX_REGEX, "");
+  const match = modelWithoutQuota.match(GEMINI_35_FLASH_REGEX);
+  if (!match) {
+    return undefined;
+  }
+
+  const level = (thinkingLevel ?? match[1] ?? "low").toLowerCase();
+  return level === "high" ? GEMINI_35_FLASH_HIGH_MODEL : GEMINI_35_FLASH_LOW_MODEL;
+}
+
+/**
  * Resolves a model name with optional tier suffix and quota prefix to its actual API model name
  * and corresponding thinking configuration.
  *
@@ -183,16 +204,20 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
   const isGemini3 = modelWithoutQuota.toLowerCase().startsWith("gemini-3");
   const skipAlias = isAntigravity && isGemini3;
 
-  // For Antigravity Gemini 3 Pro models without explicit tier, append default tier
+  // For Antigravity Gemini 3 Pro models without explicit tier, append default tier.
   // Antigravity API: gemini-3-pro requires tier suffix (gemini-3-pro-low/high)
-  //                  gemini-3-flash uses bare name + thinkingLevel param
+  //                  gemini-3.5-flash uses backend ids (gemini-3.5-flash-low / gemini-3-flash-agent)
+  //                  other gemini-3-flash models use bare name + thinkingLevel param
   // Pro defaults to -low unless an explicit tier is provided
   const isGemini3Pro = isGemini3ProModel(modelWithoutQuota);
   const isGemini3Flash = isGemini3FlashModel(modelWithoutQuota);
   
   let antigravityModel = modelWithoutQuota;
   if (skipAlias) {
-    if (isGemini3Pro && !tier && !isImageModel) {
+    const gemini35FlashBackendModel = resolveAntigravityGemini35FlashBackendModel(modelWithoutQuota, tier);
+    if (gemini35FlashBackendModel) {
+      antigravityModel = gemini35FlashBackendModel;
+    } else if (isGemini3Pro && !tier && !isImageModel) {
       antigravityModel = `${modelWithoutQuota}-low`;
     } else if (isGemini3Flash && tier) {
       antigravityModel = baseName;

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -63,6 +63,13 @@ const TIER_REGEX = /-(minimal|low|medium|high)$/;
 const QUOTA_PREFIX_REGEX = /^antigravity-/i;
 const GEMINI_3_PRO_REGEX = /^gemini-3(?:\.\d+)?-pro/i;
 const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
+/**
+ * Dotted-minor Gemini generations (gemini-3.1, gemini-3.5, ...) use BARE model
+ * names on the Gemini CLI backend, unlike the legacy 3.0 line (gemini-3-pro) which
+ * uses a "-preview" suffix. Confirmed against the antigravity (`agy`) and `gemini`
+ * CLIs, which ship `gemini-3.1-pro`/`gemini-3.1-flash` (no `-preview`).
+ */
+const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.\d+/i;
 
 // ANTIGRAVITY_ONLY_MODELS removed - all models now default to antigravity
 
@@ -342,11 +349,14 @@ export function resolveModelForHeaderStyle(
       .replace(/^antigravity-/i, "")
       .replace(/-(low|medium|high)$/i, "");
 
+    // Only the legacy 3.0 line takes a "-preview" suffix on the Gemini CLI backend.
+    // Dotted-minor generations (gemini-3.1+, gemini-3.5, ...) use bare names there.
     const hasPreviewSuffix = /-preview($|-)/i.test(transformedModel);
-    if (!hasPreviewSuffix) {
+    const usesBareName = GEMINI_DOTTED_MINOR_REGEX.test(transformedModel);
+    if (!hasPreviewSuffix && !usesBareName) {
       transformedModel = `${transformedModel}-preview`;
     }
-    
+
     return {
       ...resolveModelWithTier(transformedModel),
       quotaPreference: "gemini-cli",

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -1,6 +1,6 @@
 /**
  * Model Resolution with Thinking Tier Support
- * 
+ *
  * Resolves model names with tier suffixes (e.g., gemini-3-pro-high, claude-opus-4-6-thinking-low)
  * to their actual API model names and corresponding thinking configurations.
  */
@@ -27,11 +27,16 @@ export const THINKING_TIER_BUDGETS = {
  * Flash supports: minimal, low, medium, high
  * Pro supports: low, high (no minimal/medium)
  */
-export const GEMINI_3_THINKING_LEVELS = ["minimal", "low", "medium", "high"] as const;
+export const GEMINI_3_THINKING_LEVELS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+] as const;
 
 /**
  * Model aliases - maps user-friendly names to API model names.
- * 
+ *
  * Format:
  * - Gemini 3 Pro variants: gemini-3-pro-{low,medium,high}
  * - Claude thinking variants: claude-{model}-thinking-{low,medium,high}
@@ -69,7 +74,7 @@ const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
  * uses a "-preview" suffix. Confirmed against the antigravity (`agy`) and `gemini`
  * CLIs, which ship `gemini-3.1-pro`/`gemini-3.1-flash` (no `-preview`).
  */
-const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.\d+/i;
+const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.(?:[1-9]\d*)/i;
 
 // ANTIGRAVITY_ONLY_MODELS removed - all models now default to antigravity
 
@@ -164,20 +169,31 @@ function isGemini3FlashModel(model: string): boolean {
  * @param options - Optional configuration including cli_first preference
  * @returns Resolved model with thinking configuration
  */
-export function resolveModelWithTier(requestedModel: string, options: ModelResolverOptions = {}): ResolvedModel {
+export function resolveModelWithTier(
+  requestedModel: string,
+  options: ModelResolverOptions = {},
+): ResolvedModel {
   const isAntigravity = QUOTA_PREFIX_REGEX.test(requestedModel);
   const modelWithoutQuota = requestedModel.replace(QUOTA_PREFIX_REGEX, "");
 
   const tier = extractThinkingTierFromModel(modelWithoutQuota);
-  const baseName = tier ? modelWithoutQuota.replace(TIER_REGEX, "") : modelWithoutQuota;
+  const baseName = tier
+    ? modelWithoutQuota.replace(TIER_REGEX, "")
+    : modelWithoutQuota;
 
   const isImageModel = IMAGE_GENERATION_MODELS.test(modelWithoutQuota);
   const isClaudeModel = modelWithoutQuota.toLowerCase().includes("claude");
-  
+
   // All models default to Antigravity quota unless cli_first is enabled
   // Fallback to gemini-cli happens at the account rotation level when Antigravity is exhausted
-  const preferGeminiCli = options.cli_first === true && !isAntigravity && !isImageModel && !isClaudeModel;
-  const quotaPreference = preferGeminiCli ? "gemini-cli" as const : "antigravity" as const;
+  const preferGeminiCli =
+    options.cli_first === true &&
+    !isAntigravity &&
+    !isImageModel &&
+    !isClaudeModel;
+  const quotaPreference = preferGeminiCli
+    ? ("gemini-cli" as const)
+    : ("antigravity" as const);
   const explicitQuota = isAntigravity || isImageModel;
 
   const isGemini3 = modelWithoutQuota.toLowerCase().startsWith("gemini-3");
@@ -189,7 +205,7 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
   // Pro defaults to -low unless an explicit tier is provided
   const isGemini3Pro = isGemini3ProModel(modelWithoutQuota);
   const isGemini3Flash = isGemini3FlashModel(modelWithoutQuota);
-  
+
   let antigravityModel = modelWithoutQuota;
   if (skipAlias) {
     if (isGemini3Pro && !tier && !isImageModel) {
@@ -220,7 +236,9 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
 
   // Check if this is a Gemini 3 model (works for both aliased and skipAlias paths)
   const isEffectiveGemini3 = resolvedModel.toLowerCase().includes("gemini-3");
-  const isClaudeThinking = resolvedModel.toLowerCase().includes("claude") && resolvedModel.toLowerCase().includes("thinking");
+  const isClaudeThinking =
+    resolvedModel.toLowerCase().includes("claude") &&
+    resolvedModel.toLowerCase().includes("thinking");
 
   if (!tier) {
     // Gemini 3 models without explicit tier get a default thinkingLevel
@@ -244,7 +262,12 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
         explicitQuota,
       };
     }
-    return { actualModel: resolvedModel, isThinkingModel: isThinking, quotaPreference, explicitQuota };
+    return {
+      actualModel: resolvedModel,
+      isThinkingModel: isThinking,
+      quotaPreference,
+      explicitQuota,
+    };
   }
 
   // Gemini 3 models with tier always get thinkingLevel set
@@ -276,7 +299,9 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
 /**
  * Gets the model family for routing decisions.
  */
-export function getModelFamily(model: string): "claude" | "gemini-flash" | "gemini-pro" {
+export function getModelFamily(
+  model: string,
+): "claude" | "gemini-flash" | "gemini-pro" {
   const lower = model.toLowerCase();
   if (lower.includes("claude")) {
     return "claude";
@@ -308,7 +333,7 @@ function budgetToGemini3Level(budget: number): "low" | "medium" | "high" {
 /**
  * Resolves model name for a specific headerStyle (quota fallback support).
  * Transforms model names when switching between gemini-cli and antigravity quotas.
- * 
+ *
  * Issue #103: When quota fallback occurs, model names need to be transformed:
  * - gemini-3-flash-preview (gemini-cli) → gemini-3-flash (antigravity)
  * - gemini-3-pro-preview (gemini-cli) → gemini-3-pro-low (antigravity)
@@ -316,11 +341,11 @@ function budgetToGemini3Level(budget: number): "low" | "medium" | "high" {
  */
 export function resolveModelForHeaderStyle(
   requestedModel: string,
-  headerStyle: "antigravity" | "gemini-cli"
+  headerStyle: "antigravity" | "gemini-cli",
 ): ResolvedModel {
   const lower = requestedModel.toLowerCase();
   const isGemini3 = lower.includes("gemini-3");
-  
+
   if (!isGemini3) {
     return resolveModelWithTier(requestedModel);
   }
@@ -330,20 +355,20 @@ export function resolveModelForHeaderStyle(
       .replace(/-preview-customtools$/i, "")
       .replace(/-preview$/i, "")
       .replace(/^antigravity-/i, "");
-    
+
     const isGemini3Pro = isGemini3ProModel(transformedModel);
     const hasTierSuffix = /-(low|medium|high)$/i.test(transformedModel);
     const isImageModel = IMAGE_GENERATION_MODELS.test(transformedModel);
-    
+
     // Don't add tier suffix to image models - they don't support thinking
     if (isGemini3Pro && !hasTierSuffix && !isImageModel) {
       transformedModel = `${transformedModel}-low`;
     }
-    
+
     const prefixedModel = `antigravity-${transformedModel}`;
     return resolveModelWithTier(prefixedModel);
   }
-  
+
   if (headerStyle === "gemini-cli") {
     let transformedModel = requestedModel
       .replace(/^antigravity-/i, "")
@@ -372,7 +397,7 @@ export function resolveModelForHeaderStyle(
  */
 export function resolveModelWithVariant(
   requestedModel: string,
-  variantConfig?: VariantConfig
+  variantConfig?: VariantConfig,
 ): ResolvedModel {
   const base = resolveModelWithTier(requestedModel);
 
@@ -395,7 +420,8 @@ export function resolveModelWithVariant(
 
   if (isGemini3) {
     const level = budgetToGemini3Level(budget);
-    const isAntigravityGemini3Pro = base.quotaPreference === "antigravity" &&
+    const isAntigravityGemini3Pro =
+      base.quotaPreference === "antigravity" &&
       isGemini3ProModel(base.actualModel);
 
     let actualModel = base.actualModel;

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -69,7 +69,7 @@ const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
  * uses a "-preview" suffix. Confirmed against the antigravity (`agy`) and `gemini`
  * CLIs, which ship `gemini-3.1-pro`/`gemini-3.1-flash` (no `-preview`).
  */
-const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.\d+/i;
+const GEMINI_DOTTED_MINOR_REGEX = /^gemini-3\.(?:[1-9]\d*)/i;
 
 // ANTIGRAVITY_ONLY_MODELS removed - all models now default to antigravity
 
@@ -353,7 +353,9 @@ export function resolveModelForHeaderStyle(
     // Dotted-minor generations (gemini-3.1+, gemini-3.5, ...) use bare names there.
     const hasPreviewSuffix = /-preview($|-)/i.test(transformedModel);
     const usesBareName = GEMINI_DOTTED_MINOR_REGEX.test(transformedModel);
-    if (!hasPreviewSuffix && !usesBareName) {
+    if (usesBareName && /-preview$/i.test(transformedModel)) {
+      transformedModel = transformedModel.replace(/-preview$/i, "");
+    } else if (!hasPreviewSuffix && !usesBareName) {
       transformedModel = `${transformedModel}-preview`;
     }
 


### PR DESCRIPTION
## Summary

Adds **Gemini 3.5 Flash** and **Gemini 3.5 Pro**, plus **Gemini 3.1 Flash**, across both quota pools, and aligns the Gemini CLI model-name convention with what the antigravity (`agy`) and `gemini` CLIs actually use for the 3.1+ generation (**bare** names, not `-preview`).

### New models

- **Antigravity quota:** `antigravity-gemini-3.1-flash`, `antigravity-gemini-3.5-flash`, `antigravity-gemini-3.5-pro`
- **Gemini CLI quota (bare):** `gemini-3.1-flash`, `gemini-3.5-flash`, `gemini-3.5-pro`

Pro variants: `low`/`high`. Flash variants: `minimal`/`low`/`medium`/`high`.

### Naming convention: bare vs `-preview`

Verified against the model IDs embedded in the installed `agy` and `gemini` CLI binaries:

- **3.0 line** keeps the legacy `-preview` suffix (`gemini-3-pro-preview`, `gemini-3-flash-preview`) — unchanged.
- **3.1+ line** uses bare names (`gemini-3.1-pro`, `gemini-3.1-flash`).

`resolveModelForHeaderStyle` now appends `-preview` only for the 3.0 line; dotted-minor generations (3.1+) stay bare. The CLI-pool entry `gemini-3.1-pro-preview` is renamed to `gemini-3.1-pro`; `gemini-3.1-pro-preview-customtools` is kept as a legacy entry. Previously-configured `-preview` model strings still route correctly via the resolver (covered by retained tests).

## Changes

- `src/plugin/config/models.ts` — model registry (+6 entries; `gemini-3.1-pro-preview` → `gemini-3.1-pro`)
- `src/plugin/transform/model-resolver.ts` — bare-name handling for dotted-minor generations on the Gemini CLI backend
- Tests: `models.test.ts`, `model-resolver.test.ts`, `request.test.ts`
- `README.md` (model tables + copy-paste config), `CHANGELOG.md`

## Test plan

- `npm test` (vitest) — 1014 passing / 0 failing
- `npm run typecheck` — clean (exit 0)
- README copy-paste config validated as JSON (17 models)

## Notes

Gemini 3.5 is rollout-dependent: the plugin routes/transforms the IDs correctly, but backend availability per account depends on Google's rollout. (Gemini 3.1 Flash is already present in the `agy`/`gemini` CLIs.)

Closes #571 #572 #573
