### PR TITLE
fix: use non-empty apiKey sentinel to prevent Claude model rejection

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1450,7 +1450,7 @@ export const createAntigravityPlugin = (providerId: string) => async (
       }
 
       return {
-        apiKey: "",
+        apiKey: "antigravity-oauth",
         async fetch(input, init) {
           if (!isGenerativeLanguageRequest(input)) {
             return fetch(input, init);
@@ -3449,3 +3449,4 @@ export const __testExports = {
   resolveHeaderRoutingDecision,
   resolveQuotaFallbackHeaderStyle,
 };
+


### PR DESCRIPTION
﻿Fixes #579

### Problem
The plugin loader returns apiKey: empty string. OpenCode validates that apiKey is non-empty for non-Google-native models (Claude) but skips this check for native Google models (Gemini). Result: Gemini works, Claude fails with Google Generative AI API key is missing.

### Fix
Change apiKey: empty string to apiKey: antigravity-oauth at src/plugin.ts:1453. The custom fetch function handles all authentication, so this value is never used for actual API calls -- it just needs to pass OpenCode's non-empty validation.

### Testing
- Built and installed locally
- Gemini models continue working
- Claude models (sonnet 4.6) no longer fail on model switch