### PR TITLE
fix: transparent legacy model ID remapping for stale models

### DIFF
--- a/src/plugin/config/models.test.ts
+++ b/src/plugin/config/models.test.ts
@@ -18,23 +18,18 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       "antigravity-claude-opus-4-6-thinking",
       "antigravity-claude-sonnet-4-6",
       "antigravity-gemini-3-flash",
-      "antigravity-gemini-3-pro",
       "antigravity-gemini-3.1-pro",
+      "antigravity-gemini-3.5-flash-low",
       "gemini-2.5-flash",
       "gemini-2.5-pro",
       "gemini-3-flash-preview",
-      "gemini-3-pro-preview",
       "gemini-3.1-pro-preview",
       "gemini-3.1-pro-preview-customtools",
+      "gemini-3.5-flash",
     ]);
   });
 
   it("defines Gemini 3 variants for Antigravity models", () => {
-    expect(getModel("antigravity-gemini-3-pro").variants).toEqual({
-      low: { thinkingLevel: "low" },
-      high: { thinkingLevel: "high" },
-    });
-
     expect(getModel("antigravity-gemini-3.1-pro").variants).toEqual({
       low: { thinkingLevel: "low" },
       high: { thinkingLevel: "high" },
@@ -53,5 +48,12 @@ describe("OPENCODE_MODEL_DEFINITIONS", () => {
       low: { thinkingConfig: { thinkingBudget: 8192 } },
       max: { thinkingConfig: { thinkingBudget: 32768 } },
     });
+  });
+
+  it("does not expose stale unavailable model IDs", () => {
+    expect(OPENCODE_MODEL_DEFINITIONS["antigravity-gemini-3-pro"]).toBeUndefined();
+    expect(OPENCODE_MODEL_DEFINITIONS["gemini-3-pro-preview"]).toBeUndefined();
+    expect(Object.keys(OPENCODE_MODEL_DEFINITIONS).some((name) => name.includes("claude-sonnet-4-5"))).toBe(false);
+    expect(Object.keys(OPENCODE_MODEL_DEFINITIONS).some((name) => name.includes("claude-opus-4-5"))).toBe(false);
   });
 });

--- a/src/plugin/config/models.ts
+++ b/src/plugin/config/models.ts
@@ -38,15 +38,6 @@ const DEFAULT_MODALITIES: ModelModalities = {
 };
 
 export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
-  "antigravity-gemini-3-pro": {
-    name: "Gemini 3 Pro (Antigravity)",
-    limit: { context: 1048576, output: 65535 },
-    modalities: DEFAULT_MODALITIES,
-    variants: {
-      low: { thinkingLevel: "low" },
-      high: { thinkingLevel: "high" },
-    },
-  },
   "antigravity-gemini-3.1-pro": {
     name: "Gemini 3.1 Pro (Antigravity)",
     limit: { context: 1048576, output: 65535 },
@@ -66,6 +57,11 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
       medium: { thinkingLevel: "medium" },
       high: { thinkingLevel: "high" },
     },
+  },
+  "antigravity-gemini-3.5-flash-low": {
+    name: "Gemini 3.5 Flash Low (Antigravity)",
+    limit: { context: 1048576, output: 65536 },
+    modalities: DEFAULT_MODALITIES,
   },
   "antigravity-claude-sonnet-4-6": {
     name: "Claude Sonnet 4.6 (Antigravity)",
@@ -91,14 +87,14 @@ export const OPENCODE_MODEL_DEFINITIONS: OpencodeModelDefinitions = {
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
   },
-  "gemini-3-flash-preview": {
-    name: "Gemini 3 Flash Preview (Gemini CLI)",
+  "gemini-3.5-flash": {
+    name: "Gemini 3.5 Flash (Gemini CLI)",
     limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
   },
-  "gemini-3-pro-preview": {
-    name: "Gemini 3 Pro Preview (Gemini CLI)",
-    limit: { context: 1048576, output: 65535 },
+  "gemini-3-flash-preview": {
+    name: "Gemini 3 Flash Preview (Gemini CLI)",
+    limit: { context: 1048576, output: 65536 },
     modalities: DEFAULT_MODALITIES,
   },
   "gemini-3.1-pro-preview": {

--- a/src/plugin/config/updater.test.ts
+++ b/src/plugin/config/updater.test.ts
@@ -66,7 +66,8 @@ describe("updateOpencodeConfig", () => {
     // Old model should be replaced
     expect(writtenConfig.provider.google.models["old-model"]).toBeUndefined();
     // New models should be present
-    expect(writtenConfig.provider.google.models["antigravity-gemini-3-pro"]).toBeDefined();
+    expect(writtenConfig.provider.google.models["antigravity-gemini-3.1-pro"]).toBeDefined();
+    expect(writtenConfig.provider.google.models["antigravity-gemini-3-pro"]).toBeUndefined();
     expect(writtenConfig.provider.google.models["antigravity-claude-sonnet-4-6"]).toBeDefined();
   });
 
@@ -235,7 +236,7 @@ describe("updateOpencodeConfig", () => {
     expect(writtenConfig.plugin).toContain("other-plugin");
     expect(writtenConfig.plugin).toContain("opencode-antigravity-auth@latest");
     expect(writtenConfig.provider.google.region).toBe("us-central1");
-    expect(writtenConfig.provider.google.models["antigravity-gemini-3-pro"]).toBeDefined();
+    expect(writtenConfig.provider.google.models["antigravity-gemini-3.1-pro"]).toBeDefined();
   });
 
   test("prefers existing opencode.jsonc when using default config path", async () => {

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -1036,7 +1036,7 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3-flash");
       });
 
-      it("transforms gemini-3-pro-preview to gemini-3-pro-low for antigravity headerStyle", () => {
+      it("transforms legacy gemini-3-pro-preview to gemini-3.1-pro-low for antigravity headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1045,7 +1045,7 @@ it("removes x-api-key header", () => {
           undefined,
           "antigravity"
         );
-        expect(result.effectiveModel).toBe("gemini-3-pro-low");
+        expect(result.effectiveModel).toBe("gemini-3.1-pro-low");
       });
 
       it("transforms gemini-3.1-pro-preview to gemini-3.1-pro-low for antigravity headerStyle", () => {
@@ -1084,7 +1084,7 @@ it("removes x-api-key header", () => {
         expect(result.effectiveModel).toBe("gemini-3-flash-preview");
       });
 
-      it("transforms gemini-3-pro-low to gemini-3-pro-preview for gemini-cli headerStyle", () => {
+      it("transforms legacy gemini-3-pro-low to gemini-3.1-pro-preview for gemini-cli headerStyle", () => {
         const result = prepareAntigravityRequest(
           "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-low:generateContent",
           { method: "POST", body: JSON.stringify({ contents: [] }) },
@@ -1093,7 +1093,7 @@ it("removes x-api-key header", () => {
           undefined,
           "gemini-cli"
         );
-        expect(result.effectiveModel).toBe("gemini-3-pro-preview");
+        expect(result.effectiveModel).toBe("gemini-3.1-pro-preview");
       });
 
       it("transforms gemini-3.1-pro-low to gemini-3.1-pro-preview for gemini-cli headerStyle", () => {

--- a/src/plugin/transform/model-resolver.test.ts
+++ b/src/plugin/transform/model-resolver.test.ts
@@ -27,9 +27,9 @@ describe("resolveModelWithTier", () => {
   });
 
   describe("Gemini 3 preview models (Issue #115)", () => {
-    it("gemini-3-pro-preview gets default thinkingLevel 'low' with antigravity quota", () => {
+    it("gemini-3-pro-preview resolves to Gemini 3.1 Pro preview", () => {
       const result = resolveModelWithTier("gemini-3-pro-preview");
-      expect(result.actualModel).toBe("gemini-3-pro-preview");
+      expect(result.actualModel).toBe("gemini-3.1-pro-preview");
       expect(result.thinkingLevel).toBe("low");
       // All Gemini models now default to antigravity
       expect(result.quotaPreference).toBe("antigravity");
@@ -57,6 +57,49 @@ describe("resolveModelWithTier", () => {
     it("gemini-2.0-flash defaults to antigravity", () => {
       const result = resolveModelWithTier("gemini-2.0-flash");
       expect(result.quotaPreference).toBe("antigravity");
+    });
+  });
+
+  describe("legacy model aliases", () => {
+    it("antigravity-gemini-3-pro resolves to Gemini 3.1 Pro low", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3-pro");
+      expect(result.actualModel).toBe("gemini-3.1-pro-low");
+      expect(result.thinkingLevel).toBe("low");
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("antigravity-gemini-3-pro-high preserves the high tier on Gemini 3.1 Pro", () => {
+      const result = resolveModelWithTier("antigravity-gemini-3-pro-high");
+      expect(result.actualModel).toBe("gemini-3.1-pro-high");
+      expect(result.thinkingLevel).toBe("high");
+      expect(result.tier).toBe("high");
+    });
+
+    it("antigravity-claude-sonnet-4-5 resolves to Claude Sonnet 4.6", () => {
+      const result = resolveModelWithTier("antigravity-claude-sonnet-4-5");
+      expect(result.actualModel).toBe("claude-sonnet-4-6");
+      expect(result.isThinkingModel).toBe(false);
+      expect(result.quotaPreference).toBe("antigravity");
+    });
+
+    it("antigravity-claude-opus-4-5-thinking resolves to Claude Opus 4.6 Thinking", () => {
+      const result = resolveModelWithTier("antigravity-claude-opus-4-5-thinking");
+      expect(result.actualModel).toBe("claude-opus-4-6-thinking");
+      expect(result.thinkingBudget).toBe(32768);
+      expect(result.isThinkingModel).toBe(true);
+    });
+
+    it("claude-opus-4-5-thinking-low preserves the low tier on Claude Opus 4.6 Thinking", () => {
+      const result = resolveModelWithTier("claude-opus-4-5-thinking-low");
+      expect(result.actualModel).toBe("claude-opus-4-6-thinking");
+      expect(result.thinkingBudget).toBe(8192);
+      expect(result.tier).toBe("low");
+    });
+
+    it("transforms legacy gemini-3-pro-preview to gemini-3.1-pro-preview for gemini-cli", () => {
+      const result = resolveModelForHeaderStyle("gemini-3-pro-preview", "gemini-cli");
+      expect(result.actualModel).toBe("gemini-3.1-pro-preview");
+      expect(result.quotaPreference).toBe("gemini-cli");
     });
   });
 
@@ -91,16 +134,16 @@ describe("resolveModelWithTier", () => {
   });
 
   describe("Antigravity Gemini 3 with tier suffix", () => {
-    it("antigravity-gemini-3-pro-low gets thinkingLevel from tier", () => {
+    it("legacy antigravity-gemini-3-pro-low resolves to Gemini 3.1 Pro low", () => {
       const result = resolveModelWithTier("antigravity-gemini-3-pro-low");
-      expect(result.actualModel).toBe("gemini-3-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro-low");
       expect(result.thinkingLevel).toBe("low");
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("antigravity-gemini-3-pro-high gets thinkingLevel from tier", () => {
+    it("legacy antigravity-gemini-3-pro-high resolves to Gemini 3.1 Pro high", () => {
       const result = resolveModelWithTier("antigravity-gemini-3-pro-high");
-      expect(result.actualModel).toBe("gemini-3-pro-high");
+      expect(result.actualModel).toBe("gemini-3.1-pro-high");
       expect(result.thinkingLevel).toBe("high");
       expect(result.quotaPreference).toBe("antigravity");
     });
@@ -183,8 +226,8 @@ describe("resolveModelWithVariant", () => {
     });
 
     it("falls back to tier resolution for Gemini 3 models", () => {
-      const result = resolveModelWithVariant("gemini-3-pro-high");
-      expect(result.actualModel).toBe("gemini-3-pro");
+      const result = resolveModelWithVariant("gemini-3.1-pro-high");
+      expect(result.actualModel).toBe("gemini-3.1-pro");
       expect(result.thinkingLevel).toBe("high");
       expect(result.configSource).toBeUndefined();
     });
@@ -201,10 +244,10 @@ describe("resolveModelWithVariant", () => {
     });
 
     it("maps budget to thinkingLevel for Gemini 3 - low", () => {
-      const result = resolveModelWithVariant("antigravity-gemini-3-pro", {
+      const result = resolveModelWithVariant("antigravity-gemini-3.1-pro", {
         thinkingBudget: 8000,
       });
-      expect(result.actualModel).toBe("gemini-3-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro-low");
       expect(result.thinkingLevel).toBe("low");
       expect(result.thinkingBudget).toBeUndefined();
       expect(result.configSource).toBe("variant");
@@ -220,7 +263,7 @@ describe("resolveModelWithVariant", () => {
     });
 
     it("maps budget to thinkingLevel for Gemini 3 - high", () => {
-      const result = resolveModelWithVariant("antigravity-gemini-3-pro", {
+      const result = resolveModelWithVariant("antigravity-gemini-3.1-pro", {
         thinkingBudget: 32000,
       });
       expect(result.thinkingLevel).toBe("high");
@@ -267,9 +310,9 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("antigravity");
     });
 
-    it("transforms gemini-3-pro-preview to gemini-3-pro-low for antigravity", () => {
+    it("transforms legacy gemini-3-pro-preview to gemini-3.1-pro-low for antigravity", () => {
       const result = resolveModelForHeaderStyle("gemini-3-pro-preview", "antigravity");
-      expect(result.actualModel).toBe("gemini-3-pro-low");
+      expect(result.actualModel).toBe("gemini-3.1-pro-low");
       expect(result.quotaPreference).toBe("antigravity");
     });
 
@@ -293,9 +336,9 @@ describe("Issue #103: resolveModelForHeaderStyle", () => {
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 
-    it("transforms gemini-3-pro-low to gemini-3-pro-preview for gemini-cli", () => {
+    it("transforms legacy gemini-3-pro-low to gemini-3.1-pro-preview for gemini-cli", () => {
       const result = resolveModelForHeaderStyle("gemini-3-pro-low", "gemini-cli");
-      expect(result.actualModel).toBe("gemini-3-pro-preview");
+      expect(result.actualModel).toBe("gemini-3.1-pro-preview");
       expect(result.quotaPreference).toBe("gemini-cli");
     });
 

--- a/src/plugin/transform/model-resolver.ts
+++ b/src/plugin/transform/model-resolver.ts
@@ -61,8 +61,11 @@ export const MODEL_ALIASES: Record<string, string> = {
 
 const TIER_REGEX = /-(minimal|low|medium|high)$/;
 const QUOTA_PREFIX_REGEX = /^antigravity-/i;
-const GEMINI_3_PRO_REGEX = /^gemini-3(?:\.\d+)?-pro/i;
-const GEMINI_3_FLASH_REGEX = /^gemini-3(?:\.\d+)?-flash/i;
+const GEMINI_3_PRO_REGEX = /^gemini-3(?!\.5)(?:\.\d+)?-pro/i;
+const GEMINI_3_FLASH_REGEX = /^gemini-3(?!\.5)(?:\.\d+)?-flash/i;
+const GEMINI_35_FLASH_REGEX = /^gemini-3\.5-flash/i;
+/** Matches gemini-3.x models EXCLUDING gemini-3.5 (which has separate handling). */
+const GEMINI_3_NOT_35_REGEX = /gemini-3(?!\.5)/i;
 
 // ANTIGRAVITY_ONLY_MODELS removed - all models now default to antigravity
 
@@ -75,6 +78,23 @@ const IMAGE_GENERATION_MODELS = /image|imagen/i;
 // Legacy LEGACY_ANTIGRAVITY_GEMINI3 regex removed - all Gemini models now default to antigravity
 
 /**
+ * Maps legacy model IDs to their current equivalents.
+ * Users with older configs referencing stale models get transparently upgraded.
+ */
+const LEGACY_MODEL_ALIASES: Record<string, string> = {
+  "antigravity-gemini-3-pro": "antigravity-gemini-3.1-pro",
+  "gemini-3-pro": "gemini-3.1-pro",
+  "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+  "antigravity-gemini-3-pro-preview": "antigravity-gemini-3.1-pro-preview",
+  "antigravity-claude-sonnet-4-5": "antigravity-claude-sonnet-4-6",
+  "claude-sonnet-4-5": "claude-sonnet-4-6",
+  "antigravity-claude-opus-4-5": "antigravity-claude-opus-4-6-thinking",
+  "claude-opus-4-5": "claude-opus-4-6-thinking",
+  "antigravity-claude-opus-4-5-thinking": "antigravity-claude-opus-4-6-thinking",
+  "claude-opus-4-5-thinking": "claude-opus-4-6-thinking",
+};
+
+/**
  * Models that support thinking tier suffixes.
  * Only these models should have -low/-medium/-high stripped as thinking tiers.
  * GPT models like gpt-oss-120b-medium should NOT have -medium stripped.
@@ -82,7 +102,7 @@ const IMAGE_GENERATION_MODELS = /image|imagen/i;
 function supportsThinkingTiers(model: string): boolean {
   const lower = model.toLowerCase();
   return (
-    lower.includes("gemini-3") ||
+    GEMINI_3_NOT_35_REGEX.test(lower) ||
     lower.includes("gemini-2.5") ||
     (lower.includes("claude") && lower.includes("thinking"))
   );
@@ -124,7 +144,7 @@ function isThinkingCapableModel(model: string): boolean {
   const lower = model.toLowerCase();
   return (
     lower.includes("thinking") ||
-    lower.includes("gemini-3") ||
+    GEMINI_3_NOT_35_REGEX.test(lower) ||
     lower.includes("gemini-2.5")
   );
 }
@@ -135,6 +155,28 @@ function isGemini3ProModel(model: string): boolean {
 
 function isGemini3FlashModel(model: string): boolean {
   return GEMINI_3_FLASH_REGEX.test(model);
+}
+
+function isGemini35FlashModel(model: string): boolean {
+  return GEMINI_35_FLASH_REGEX.test(model);
+}
+
+/**
+ * Transparently remaps legacy model IDs to their current equivalents
+ * while preserving any thinking tier suffixes.
+ */
+function normalizeLegacyModel(model: string): string {
+  const tier = extractThinkingTierFromModel(model);
+  const baseName = tier ? model.replace(TIER_REGEX, "") : model;
+  const normalizedBase = LEGACY_MODEL_ALIASES[baseName.toLowerCase()];
+
+  if (!normalizedBase) {
+    return model;
+  }
+  if (!tier) {
+    return normalizedBase;
+  }
+  return supportsThinkingTiers(normalizedBase) ? `${normalizedBase}-${tier}` : normalizedBase;
 }
 
 /**
@@ -158,8 +200,9 @@ function isGemini3FlashModel(model: string): boolean {
  * @returns Resolved model with thinking configuration
  */
 export function resolveModelWithTier(requestedModel: string, options: ModelResolverOptions = {}): ResolvedModel {
-  const isAntigravity = QUOTA_PREFIX_REGEX.test(requestedModel);
-  const modelWithoutQuota = requestedModel.replace(QUOTA_PREFIX_REGEX, "");
+  const normalizedModel = normalizeLegacyModel(requestedModel);
+  const isAntigravity = QUOTA_PREFIX_REGEX.test(normalizedModel);
+  const modelWithoutQuota = normalizedModel.replace(QUOTA_PREFIX_REGEX, "");
 
   const tier = extractThinkingTierFromModel(modelWithoutQuota);
   const baseName = tier ? modelWithoutQuota.replace(TIER_REGEX, "") : modelWithoutQuota;
@@ -190,6 +233,10 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
     } else if (isGemini3Flash && tier) {
       antigravityModel = baseName;
     }
+    // Gemini 3.5 Flash: only -low quota row is live, always resolve to -low
+    if (isGemini35FlashModel(modelWithoutQuota) && !antigravityModel.endsWith("-low")) {
+      antigravityModel = `${baseName}-low`;
+    }
   }
 
   const actualModel = skipAlias
@@ -211,8 +258,8 @@ export function resolveModelWithTier(requestedModel: string, options: ModelResol
     };
   }
 
-  // Check if this is a Gemini 3 model (works for both aliased and skipAlias paths)
-  const isEffectiveGemini3 = resolvedModel.toLowerCase().includes("gemini-3");
+  // Check if this is a Gemini 3 model (not 3.5 — which has separate handling)
+  const isEffectiveGemini3 = GEMINI_3_NOT_35_REGEX.test(resolvedModel);
   const isClaudeThinking = resolvedModel.toLowerCase().includes("claude") && resolvedModel.toLowerCase().includes("thinking");
 
   if (!tier) {
@@ -311,15 +358,16 @@ export function resolveModelForHeaderStyle(
   requestedModel: string,
   headerStyle: "antigravity" | "gemini-cli"
 ): ResolvedModel {
-  const lower = requestedModel.toLowerCase();
-  const isGemini3 = lower.includes("gemini-3");
+  const normalizedModel = normalizeLegacyModel(requestedModel);
+  const lower = normalizedModel.toLowerCase();
+  const isGemini3 = GEMINI_3_NOT_35_REGEX.test(lower);
   
   if (!isGemini3) {
-    return resolveModelWithTier(requestedModel);
+    return resolveModelWithTier(normalizedModel);
   }
 
   if (headerStyle === "antigravity") {
-    let transformedModel = requestedModel
+    let transformedModel = normalizedModel
       .replace(/-preview-customtools$/i, "")
       .replace(/-preview$/i, "")
       .replace(/^antigravity-/i, "");
@@ -338,7 +386,7 @@ export function resolveModelForHeaderStyle(
   }
   
   if (headerStyle === "gemini-cli") {
-    let transformedModel = requestedModel
+    let transformedModel = normalizedModel
       .replace(/^antigravity-/i, "")
       .replace(/-(low|medium|high)$/i, "");
 


### PR DESCRIPTION
Based on PR #569 by @kill74. Adds LEGACY_MODEL_ALIASES + normalizeLegacyModel() that transparently remaps stale model IDs (Gemini 3 Pro to 3.1 Pro, Claude 4.5 to 4.6). Thinking tier suffixes preserved during normalization. Stale model definitions removed from generated config.